### PR TITLE
api: add health and readiness endpoints

### DIFF
--- a/game-simulation/internal/api/server.go
+++ b/game-simulation/internal/api/server.go
@@ -18,12 +18,32 @@ func NewHandler(debugMode bool, allowedOrigin string) http.Handler {
 	server := &Server{debugMode: debugMode}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", server.healthHandler)
+	mux.HandleFunc("/readyz", server.readyHandler)
 	mux.HandleFunc("/simulate", server.simulateHandler)
 	mux.HandleFunc("/optimize", server.optimizeHandler)
 
 	return cors.New(cors.Options{
 		AllowedOrigins: []string{allowedOrigin},
 	}).Handler(mux)
+}
+
+func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Invalid request method", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Invalid request method", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *Server) simulateHandler(w http.ResponseWriter, r *http.Request) {

--- a/game-simulation/internal/api/server_test.go
+++ b/game-simulation/internal/api/server_test.go
@@ -19,6 +19,35 @@ func TestSimulateHandlerAcceptsValidPayload(t *testing.T) {
 	}
 }
 
+func TestHealthAndReadinessHandlers(t *testing.T) {
+	handler := NewHandler(true, "http://localhost:3000")
+
+	testCases := []struct {
+		name   string
+		path   string
+		method string
+		want   int
+	}{
+		{name: "health ok", path: "/healthz", method: http.MethodGet, want: http.StatusOK},
+		{name: "ready ok", path: "/readyz", method: http.MethodGet, want: http.StatusOK},
+		{name: "health rejects post", path: "/healthz", method: http.MethodPost, want: http.StatusMethodNotAllowed},
+		{name: "ready rejects post", path: "/readyz", method: http.MethodPost, want: http.StatusMethodNotAllowed},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := httptest.NewRequest(testCase.method, testCase.path, nil)
+			response := httptest.NewRecorder()
+
+			handler.ServeHTTP(response, request)
+
+			if response.Code != testCase.want {
+				t.Fatalf("%s status = %d, want %d", testCase.path, response.Code, testCase.want)
+			}
+		})
+	}
+}
+
 func TestSimulateHandlerRejectsInvalidPayloads(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/stat-api-server/cmd/stat-api-server/main.go
+++ b/stat-api-server/cmd/stat-api-server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"log"
 	"net/http"
@@ -23,7 +24,9 @@ func main() {
 	defer db.Close()
 	log.Println("Connected to database")
 
-	server := api.NewServer(store.NewSQLStatStore(db))
+	server := api.NewServer(store.NewSQLStatStore(db), func(ctx context.Context) error {
+		return db.PingContext(ctx)
+	})
 	handler := api.NewHandler(server, allowedOrigin)
 
 	log.Printf("Server started at :%s", port)

--- a/stat-api-server/internal/api/server.go
+++ b/stat-api-server/internal/api/server.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
@@ -21,22 +23,50 @@ type StatStore interface {
 }
 
 type Server struct {
-	store StatStore
+	store      StatStore
+	readyCheck func(context.Context) error
 }
 
-func NewServer(store StatStore) *Server {
-	return &Server{store: store}
+func NewServer(store StatStore, readyCheck func(context.Context) error) *Server {
+	return &Server{
+		store:      store,
+		readyCheck: readyCheck,
+	}
 }
 
 func NewHandler(server *Server, allowedOrigin string) http.Handler {
 	router := mux.NewRouter()
 	router.StrictSlash(true)
+	router.HandleFunc("/healthz", server.HealthHandler).Methods(http.MethodGet)
+	router.HandleFunc("/readyz", server.ReadyHandler).Methods(http.MethodGet)
 	router.HandleFunc("/teams", server.GetTeamsHandler).Methods(http.MethodGet)
 	router.HandleFunc("/batting", server.GetBattingStatHandler).Methods(http.MethodGet)
 
 	return cors.New(cors.Options{
 		AllowedOrigins: []string{allowedOrigin},
 	}).Handler(router)
+}
+
+func (s *Server) HealthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) ReadyHandler(w http.ResponseWriter, r *http.Request) {
+	if s.readyCheck == nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
+
+	if err := s.readyCheck(ctx); err != nil {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+		log.Println(err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *Server) GetTeamsHandler(w http.ResponseWriter, r *http.Request) {

--- a/stat-api-server/internal/api/server_test.go
+++ b/stat-api-server/internal/api/server_test.go
@@ -1,7 +1,9 @@
 package api_test
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -17,7 +19,7 @@ func TestGetTeams(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := api.NewServer(store.NewMockStatStore())
+	server := api.NewServer(store.NewMockStatStore(), nil)
 
 	response := httptest.NewRecorder()
 	handler := http.HandlerFunc(server.GetTeamsHandler)
@@ -39,7 +41,7 @@ func TestGetBatting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := api.NewServer(store.NewMockStatStore())
+	server := api.NewServer(store.NewMockStatStore(), nil)
 
 	response := httptest.NewRecorder()
 	handler := http.HandlerFunc(server.GetBattingStatHandler)
@@ -66,4 +68,60 @@ func isJSONEqual(obj1, obj2 string) bool {
 		return false
 	}
 	return reflect.DeepEqual(o1, o2)
+}
+
+func TestHealthz(t *testing.T) {
+	server := api.NewServer(store.NewMockStatStore(), nil)
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+
+	handler := api.NewHandler(server, "http://localhost:3000")
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("healthz status = %d, want %d", response.Code, http.StatusOK)
+	}
+}
+
+func TestReadyz(t *testing.T) {
+	testCases := []struct {
+		name       string
+		readyCheck func(context.Context) error
+		wantStatus int
+	}{
+		{
+			name:       "ready without check",
+			readyCheck: nil,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "ready with healthy check",
+			readyCheck: func(context.Context) error {
+				return nil
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "ready with failing check",
+			readyCheck: func(context.Context) error {
+				return errors.New("db down")
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := api.NewServer(store.NewMockStatStore(), testCase.readyCheck)
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+			handler := api.NewHandler(server, "http://localhost:3000")
+			handler.ServeHTTP(response, request)
+
+			if response.Code != testCase.wantStatus {
+				t.Fatalf("readyz status = %d, want %d", response.Code, testCase.wantStatus)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- add `/healthz` and `/readyz` endpoints to the game simulation service
- add `/healthz` and database-backed `/readyz` endpoints to the stat API service
- cover the new probe behavior with handler tests in both services

## Testing
- `GOCACHE=/tmp/lineup-lab-go-cache go test ./...` in `game-simulation`
- `GOCACHE=/tmp/lineup-lab-go-cache go test ./...` in `stat-api-server`

Closes #14