### PR TITLE
docs: fix Vite frontend development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ npm start
 
 The frontend development server uses `frontend/.env.development` to target the local backend services by default:
 
-- `REACT_APP_STAT_API_BASE_URL=http://localhost:8082`
-- `REACT_APP_SIMULATION_API_BASE_URL=http://localhost:8081`
+- `VITE_STAT_API_BASE_URL=http://localhost:8082`
+- `VITE_SIMULATION_API_BASE_URL=http://localhost:8081`
 
-Open [http://localhost:3000](http://localhost:3000) to use the CRA development server.
+Open [http://localhost:3000](http://localhost:3000) to use the Vite development server.
 
 ## Configuration
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,11 +20,14 @@ npm start
 
 The development server loads API URLs from `frontend/.env.development`, so it targets the local backend services by default.
 
+- `VITE_STAT_API_BASE_URL=http://localhost:8082`
+- `VITE_SIMULATION_API_BASE_URL=http://localhost:8081`
+
 To run the frontend tests, use:
 ```sh
 npm test
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Open [http://localhost:3000](http://localhost:3000) to view it in the browser with the Vite development server.
 
 For the full local architecture, Docker Compose workflow, and environment variable setup, use the repository root README.


### PR DESCRIPTION
## Summary
- update the local frontend env var names in the docs from `REACT_APP_*` to `VITE_*`
- describe the frontend development server as Vite instead of CRA

## Why
The frontend has already been migrated to Vite, but the development docs on `main` still referred to the old CRA env names and tooling. This follow-up keeps the README docs aligned with the current setup.

## Testing
- documentation-only change