### PR TITLE
ci: upgrade checkout action to v5

### DIFF
--- a/.github/workflows/compose-config.yml
+++ b/.github/workflows/compose-config.yml
@@ -23,7 +23,7 @@ jobs:
   validate-compose:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Render default Compose config
         run: |

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -13,7 +13,7 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/game-simulation.yml
+++ b/.github/workflows/game-simulation.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -26,7 +26,7 @@ jobs:
           - stat-api-server
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/stat-api-server.yml
+++ b/.github/workflows/stat-api-server.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
       uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary
- replace `actions/checkout@v4` with `actions/checkout@v5` in all workflows
- address the GitHub Actions Node 20 deprecation warning with the Node 24 runtime update
- keep the change minimal without broader workflow version churn

## Testing
- workflow definition update only