### PR TITLE
Add Python CI checks for auth-api

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,34 @@
+name: Check Python services
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "auth-api/**"
+      - ".github/workflows/python-lint.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "auth-api/**"
+      - ".github/workflows/python-lint.yml"
+  workflow_dispatch:
+
+jobs:
+  auth-api-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: auth-api/requirements.txt
+
+      - name: Install lint dependencies
+        run: pip install ruff
+
+      - name: Run Ruff
+        run: ruff check auth-api

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
     paths:
+      - "auth-api/**"
       - "frontend/**"
       - "game-simulation/**"
       - "stat-api-server/**"
@@ -11,6 +12,7 @@ on:
   pull_request:
     branches: ["main"]
     paths:
+      - "auth-api/**"
       - "frontend/**"
       - "game-simulation/**"
       - "stat-api-server/**"
@@ -18,6 +20,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  auth-api-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: auth-api/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r auth-api/requirements.txt
+
+      - name: Run auth-api tests
+        run: PYTHONPATH=auth-api pytest auth-api/tests -q
+
   go-coverage:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary
- add an `auth-api` unit-test job to the shared test workflow
- add a dedicated Python lint workflow using Ruff
- trigger the new Python CI jobs when `auth-api` files change

## Verification
- `docker run --rm -v "$PWD:/workspace" -w /workspace python:3.12-slim sh -lc "pip install --no-cache-dir -r auth-api/requirements.txt >/tmp/pip.log && PYTHONPATH=auth-api pytest auth-api/tests -q"`
- `docker run --rm -v "$PWD:/workspace" -w /workspace python:3.12-slim sh -lc "pip install --no-cache-dir ruff >/tmp/pip.log && ruff check auth-api"`