### PR TITLE
Add Docker Compose gateway smoke test

### DIFF
--- a/.github/workflows/compose-config.yml
+++ b/.github/workflows/compose-config.yml
@@ -4,16 +4,20 @@ on:
   push:
     branches: [ "main" ]
     paths:
+      - ".github/workflows/compose-config.yml"
       - "docker-compose.yml"
       - ".env.example"
+      - "gateway/**"
       - "frontend/**"
       - "game-simulation/**"
       - "stat-api-server/**"
   pull_request:
     branches: [ "main" ]
     paths:
+      - ".github/workflows/compose-config.yml"
       - "docker-compose.yml"
       - ".env.example"
+      - "gateway/**"
       - "frontend/**"
       - "game-simulation/**"
       - "stat-api-server/**"
@@ -122,3 +126,76 @@ jobs:
           fi
 
           grep -F "STAT_API_SERVER_DATABASE_URL must be set" /tmp/compose-missing-env.log
+
+  gateway-smoke-test:
+    runs-on: ubuntu-latest
+    env:
+      POSTGRES_DB: mydatabase
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: change-me
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: change-me
+      STAT_API_SERVER_DATABASE_URL: postgres://myuser:change-me@db/mydatabase?sslmode=disable
+      GAME_SIMULATION_DEBUG: "1"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Start Docker Compose stack
+        run: docker compose up -d --build
+
+      - name: Wait for gateway frontend response
+        run: |
+          for attempt in $(seq 1 30); do
+            if curl -fsS http://localhost:8080/ > gateway-root.html; then
+              exit 0
+            fi
+
+            sleep 2
+          done
+
+          echo "Gateway did not start serving the frontend in time"
+          docker compose logs --no-color
+          exit 1
+
+      - name: Verify gateway serves the frontend
+        run: |
+          grep -F "<title>Lineup Lab</title>" gateway-root.html
+
+      - name: Wait for proxied teams endpoint
+        run: |
+          for attempt in $(seq 1 30); do
+            status="$(curl -s -o teams.json -w '%{http_code}' http://localhost:8080/api/teams)"
+            if [ "$status" = "200" ]; then
+              exit 0
+            fi
+
+            sleep 2
+          done
+
+          echo "Gateway did not proxy /api/teams successfully in time"
+          docker compose logs --no-color
+          exit 1
+
+      - name: Verify teams response is valid JSON
+        run: |
+          python3 - <<'PY'
+          import json
+
+          with open("teams.json", "r", encoding="utf-8") as f:
+              payload = json.load(f)
+
+          assert isinstance(payload, list), payload
+          PY
+
+      - name: Verify unknown API path returns 404 instead of frontend HTML
+        run: |
+          status="$(curl -s -o api-not-found.txt -w '%{http_code}' http://localhost:8080/api/not-found)"
+          test "$status" = "404"
+          if grep -Fq "<title>Lineup Lab</title>" api-not-found.txt; then
+            echo "Unknown API path returned frontend HTML"
+            exit 1
+          fi
+
+      - name: Tear down Docker Compose stack
+        if: always()
+        run: docker compose down -v


### PR DESCRIPTION
## Summary
- add a runtime Docker Compose smoke test for the gateway stack
- verify the gateway serves the frontend and proxies `/api/teams`
- assert unknown `/api/*` paths return `404` instead of frontend HTML
- run the Compose workflow when `gateway/**` changes

## Verification
- `docker compose up -d --build` with CI-style env
- verified `GET /` returns the frontend HTML title through the gateway
- verified `GET /api/teams` returns a successful JSON response through the gateway
- verified `GET /api/not-found` returns `404` and not the frontend HTML
- `docker compose down -v`

Closes #91