### PR TITLE
Adopt pydantic-settings for auth config

### DIFF
--- a/auth/app/config.py
+++ b/auth/app/config.py
@@ -1,30 +1,29 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-import os
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-@dataclass(frozen=True)
-class Settings:
-    app_name: str
-    database_url: str | None
-    port: int
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(extra="ignore", populate_by_name=True)
 
+    app_name: str = Field(default="lineup-lab-auth", alias="APP_NAME")
+    database_url: str | None = Field(default=None, alias="DATABASE_URL")
+    port: int = Field(default=8000, alias="PORT", validate_default=True)
 
-def parse_port(value: str) -> int:
-    try:
-        port = int(value)
-    except ValueError as err:
-        raise ValueError("PORT must be a valid integer") from err
+    @field_validator("port", mode="before")
+    @classmethod
+    def validate_port(cls, value: object) -> int:
+        try:
+            port = int(value)
+        except (TypeError, ValueError) as err:
+            raise ValueError("PORT must be a valid integer") from err
 
-    if port <= 0:
-        raise ValueError("PORT must be greater than 0")
+        if port <= 0:
+            raise ValueError("PORT must be greater than 0")
 
-    return port
+        return port
 
 
 def get_settings() -> Settings:
-    port = parse_port(os.getenv("PORT", "8000"))
-    database_url = os.getenv("DATABASE_URL")
-    app_name = os.getenv("APP_NAME", "lineup-lab-auth")
-    return Settings(app_name=app_name, database_url=database_url, port=port)
+    return Settings()

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.116.1
+pydantic-settings==2.10.1
 uvicorn==0.35.0
 sqlalchemy==2.0.43
 psycopg[binary]==3.2.9

--- a/auth/tests/test_config.py
+++ b/auth/tests/test_config.py
@@ -1,0 +1,42 @@
+import pytest
+from pydantic import ValidationError
+
+from app.config import get_settings
+
+
+def test_get_settings_uses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("APP_NAME", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("PORT", raising=False)
+
+    settings = get_settings()
+
+    assert settings.app_name == "lineup-lab-auth"
+    assert settings.database_url is None
+    assert settings.port == 8000
+
+
+def test_get_settings_reads_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("APP_NAME", "test-auth")
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:pass@postgres/example")
+    monkeypatch.setenv("PORT", "9000")
+
+    settings = get_settings()
+
+    assert settings.app_name == "test-auth"
+    assert settings.database_url == "postgres://user:pass@postgres/example"
+    assert settings.port == 9000
+
+
+def test_get_settings_rejects_invalid_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PORT", "not-a-number")
+
+    with pytest.raises(ValidationError, match="PORT must be a valid integer"):
+        get_settings()
+
+
+def test_get_settings_rejects_non_positive_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PORT", "0")
+
+    with pytest.raises(ValidationError, match="PORT must be greater than 0"):
+        get_settings()


### PR DESCRIPTION
## Summary
- replace the auth service's custom env parsing with `pydantic-settings`
- keep port validation explicit with typed settings validation
- add config tests for defaults, env overrides, and invalid port values

## Verification
- `docker run --rm -v "$PWD:/workspace" -w /workspace/auth python:3.12-slim sh -lc "pip install --no-cache-dir -r requirements.txt >/tmp/pip.log && PYTHONPATH=/workspace/auth pytest tests -q"`
- `docker run --rm -v "$PWD:/workspace" -w /workspace/auth python:3.12-slim sh -lc "pip install --no-cache-dir ruff >/tmp/pip.log && ruff check app tests"`

Closes #98