### PR TITLE
docs: choose shared Postgres migration strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Notes:
 - `docker-compose.yml` requires several env vars explicitly and fails fast if they are missing
 - the browser only talks to the gateway origin in Docker Compose; the gateway routes `/api/*` to the internal backend services
 - the frontend source lives in `frontend/`, but the runtime entrypoint is the `gateway` service
+- shared Postgres schema evolution is defined in [docs/adr/0003-shared-postgres-migration-strategy.md](docs/adr/0003-shared-postgres-migration-strategy.md), with Atlas planned as the repo-wide migration workflow
 
 ## Health And Readiness Endpoints
 
@@ -193,6 +194,7 @@ The frontend coverage summary is written to `frontend/coverage/coverage-summary.
 
 - frontend app: [frontend/README.md](frontend/README.md)
 - auth service: [auth/README.md](auth/README.md)
+- postgres bootstrap and migration notes: [postgres/README.md](postgres/README.md)
 - architecture decisions: [docs/adr/README.md](docs/adr/README.md)
 - auth session strategy: [docs/auth-session-strategy.md](docs/auth-session-strategy.md)
 - local env template: [.env.example](.env.example)

--- a/auth/README.md
+++ b/auth/README.md
@@ -12,6 +12,7 @@ Ownership:
 - `auth` owns the `users` and `sessions` tables
 - other services should not write auth-domain tables directly
 - the shared Postgres instance does not change that logical ownership model
+- auth-owned schema changes should follow the shared migration strategy in [docs/adr/0003-shared-postgres-migration-strategy.md](../docs/adr/0003-shared-postgres-migration-strategy.md)
 
 See the architecture decision record:
 - [docs/adr/0002-auth-owns-users-and-sessions.md](../docs/adr/0002-auth-owns-users-and-sessions.md)

--- a/docs/adr/0003-shared-postgres-migration-strategy.md
+++ b/docs/adr/0003-shared-postgres-migration-strategy.md
@@ -1,0 +1,159 @@
+# ADR 0003: shared Postgres migration strategy
+
+## Status
+
+Accepted
+
+## Context
+
+Lineup Lab currently initializes Postgres from a single bootstrap SQL file:
+
+- [`postgres/init-table.sql`](../../postgres/init-table.sql)
+
+That approach works for a brand-new local database, but it becomes fragile once
+multiple services own schema in the same Postgres instance:
+
+- `stats` owns baseball data tables such as `batting`
+- `auth` owns `users` and `sessions`
+- future issues will add scoreboard and async-job tables
+
+We need one migration workflow for the shared database rather than one tool per
+language or per service. Otherwise we would end up with fragmented ordering,
+review, and rollout behavior against the same Postgres instance.
+
+## Decision
+
+Lineup Lab will use Atlas as the repo-wide migration workflow for the shared
+Postgres database.
+
+The primary Atlas workflow for this project is versioned migrations.
+Declarative or schema-diff features may still be useful as supporting tooling,
+but the reviewed and deployed artifact should be an ordered migration chain.
+
+Additional rules:
+
+- the ordered migration chain is the source of truth for schema evolution
+- fresh databases and existing databases should both converge by applying the
+  migration chain
+- migration files live under `postgres/migrations/`
+- migration files should stay SQL-first and language-agnostic
+- migration filenames should use an Atlas-managed ordered version prefix plus a
+  service ownership hint, for example
+  `20260412210000_auth_add_users_display_name.sql`
+- each migration file must include a top-of-file SQL comment naming the owning
+  service, for example `-- owner: auth`
+- services must not run schema migrations automatically on application startup
+- migrations should run in a dedicated step after the database is reachable and
+  before application versions that depend on the new schema are rolled out
+
+`postgres/init-table.sql` may remain temporarily as local bootstrap convenience
+while the repo transitions, but it is no longer the long-term source of truth
+and should eventually be removed or reduced to setup-only behavior once Atlas is
+fully in place.
+
+## Why Atlas
+
+Atlas fits this repo well because:
+
+- it is language-agnostic and works across Go and Python services
+- it supports versioned migrations, which matches the immediate need here
+- it also has a Kubernetes path later without forcing Kubernetes to be the
+  migration entrypoint today
+- it avoids making the shared database migration workflow depend on one service
+  framework
+
+Versioned migrations are the better primary fit for this repo because they make
+upgrade sequencing, rollout ordering, and review more explicit while the project
+still uses a shared Postgres database across multiple services.
+
+## Alternatives Considered
+
+### Keep bootstrap SQL only
+
+Rejected.
+
+That remains simple in the short term, but it does not provide a safe upgrade
+path for existing environments and makes multi-service schema review harder.
+
+### Use Alembic
+
+Rejected.
+
+Alembic is a Python migration tool commonly paired with SQLAlchemy. It would fit
+`auth`, but not the shared repository as a whole. Choosing it would make
+database evolution feel owned by the Python stack even when the affected schema
+belongs to `stats` or future non-Python services.
+
+### Use separate migration tools per service
+
+Rejected.
+
+That would fragment ordering, CI, and deployment behavior while the database is
+still shared. Schema ownership can stay per service, but migration execution
+should stay database-wide and unified.
+
+### Use CNCF SchemaHero
+
+Rejected for now.
+
+SchemaHero is the most relevant CNCF-native option and has a strong
+Kubernetes-oriented model, but Atlas is a better fit for the current repo stage:
+it works cleanly in local development and CI today while still supporting a
+future Kubernetes migration story.
+
+### Let each service mutate schema on startup
+
+Rejected.
+
+That increases rollout risk, makes ownership less explicit, and is awkward for
+future Kubernetes deployments where schema changes should be applied once in a
+controlled step.
+
+## Consequences
+
+- future schema PRs should add Atlas-managed migrations under
+  `postgres/migrations/`
+- local development, CI, and future Kubernetes deployments should all rely on
+  the same migration chain
+- fresh-install and upgrade-path testing should both be explicit in CI
+- service docs and PRs should call out schema ownership and migration impact
+- follow-up implementation work should add:
+  - Atlas tooling and commands to the repo
+  - migration application in CI
+  - a clear path for local and Kubernetes execution
+
+## Testing Expectations
+
+The migration workflow should eventually verify both:
+
+- fresh install:
+  - start from an empty database
+  - apply the full Atlas migration chain
+  - confirm the resulting schema matches expectations
+- upgrade path:
+  - start from an older schema state
+  - apply only pending migrations
+  - confirm the resulting schema matches the same expected end state
+
+## Example Future Change
+
+If `auth` later needs to add `display_name` to `users`, the expected flow is:
+
+1. Add a migration such as
+   `postgres/migrations/20260412210000_auth_add_users_display_name.sql`
+2. Put the schema change in that file, for example:
+
+   ```sql
+   -- owner: auth
+   ALTER TABLE users
+   ADD COLUMN display_name VARCHAR(100);
+   ```
+
+3. Apply that migration through the shared Atlas workflow
+4. Update the owning service code after the schema contract is clear
+5. In CI, verify both:
+   - a fresh database migrated from zero
+   - an older database upgraded through pending migrations
+
+That keeps fresh installs and upgrade installs converging on the same schema
+without maintaining two independent sources of truth.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,7 @@ Current ADRs:
 
 - [0001-single-public-api-entrypoint.md](0001-single-public-api-entrypoint.md)
 - [0002-auth-owns-users-and-sessions.md](0002-auth-owns-users-and-sessions.md)
+- [0003-shared-postgres-migration-strategy.md](0003-shared-postgres-migration-strategy.md)
 
 Suggested format:
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,0 +1,55 @@
+# Postgres
+
+This directory contains the local Postgres image and schema bootstrap files for
+Lineup Lab.
+
+## Current Local Bootstrap
+
+- [`init-table.sql`](./init-table.sql)
+  is copied into `/docker-entrypoint-initdb.d/`
+- the file is applied only when Postgres starts with a brand-new empty data
+  directory
+- this still makes fresh local development easy to boot today
+- however, it is now transitional bootstrap convenience rather than the
+  long-term schema source of truth
+
+## Migration Strategy
+
+The project now treats Atlas-managed migrations as the source of truth for
+schema evolution.
+
+Per [ADR 0003](../docs/adr/0003-shared-postgres-migration-strategy.md):
+
+- the ordered migration chain under `postgres/migrations/` is the source of
+  truth
+- fresh databases and upgraded databases should both converge by applying that
+  migration chain
+- Atlas versioned migrations are the primary workflow for this repo
+- schema changes should be reviewed with explicit service ownership, such as
+  `auth`, `stats`, or a future scoreboard service
+- migrations should be applied by a dedicated migration step, not by app
+  startup side effects
+- CI should verify both fresh-install and upgrade-path behavior
+- `init-table.sql` can remain temporarily during the transition, but it should
+  not diverge from the migration chain and should not be treated as the
+  canonical schema forever
+
+## What To Do For Future Schema Changes
+
+1. Add a forward-only SQL migration under `postgres/migrations/`
+   - let Atlas create the ordered version prefix
+   - use a descriptive suffix with service ownership, for example
+     `20260412210000_auth_add_users_display_name.sql`
+   - include a top-of-file ownership comment such as `-- owner: auth`
+2. Mention schema ownership and migration impact in the PR
+3. Keep `init-table.sql` aligned only while the transition period still exists
+
+Do not rely on service startup to apply schema changes. The intended future
+flow is:
+
+1. start or reach the target database
+2. run the Atlas migration step once
+3. deploy the service versions that depend on the new schema
+
+The Atlas integration itself is a follow-up implementation step. This issue
+chooses the workflow and review expectations.

--- a/postgres/migrations/README.md
+++ b/postgres/migrations/README.md
@@ -1,0 +1,23 @@
+# Postgres Migrations
+
+Atlas-managed versioned SQL migrations will live in this directory.
+
+Intended conventions:
+
+- use forward-only SQL files
+- let Atlas create the ordered version prefix
+- keep filenames descriptive, for example
+  `20260412210000_auth_create_sessions.sql`
+- add a top-of-file ownership comment such as `-- owner: auth`
+- plan for upgrade-path testing as well as fresh-bootstrap testing
+
+Expected future validation:
+
+- fresh-install test: empty database + full migration chain reaches the expected
+  schema
+- upgrade test: older schema state + pending migrations reaches the same schema
+
+The Atlas wiring is not implemented yet. This directory exists now so the
+strategy chosen in
+[ADR 0003](../../docs/adr/0003-shared-postgres-migration-strategy.md)
+has a concrete home in the repository.


### PR DESCRIPTION
Closes #97

## Summary
- add ADR 0003 for the shared Postgres migration strategy
- choose Atlas as the repo-wide migration workflow
- document migration naming, ownership, and fresh-install versus upgrade-path expectations
- add postgres docs to explain the transition away from `init-table.sql` as the long-term source of truth

## Verification
- docs-only change
