### PR TITLE
Add password hashing and credential validation to auth

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -6,6 +6,9 @@ Current scope:
 - health and readiness endpoints
 - database configuration and connectivity checks
 - SQLAlchemy models for the `users` and `sessions` tables
+- Argon2-based password hashing helpers and credential validation
+  - configurable hash cost settings for auth environments
+  - length-based password validation aligned with NIST/OWASP-style guidance
 - placeholder auth and user routes that reserve the public API shape
 
 Ownership:

--- a/auth/app/config.py
+++ b/auth/app/config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -9,6 +7,9 @@ class Settings(BaseSettings):
 
     app_name: str = Field(default="lineup-lab-auth", alias="APP_NAME")
     database_url: str | None = Field(default=None, alias="DATABASE_URL")
+    password_hash_time_cost: int = Field(default=3, alias="PASSWORD_HASH_TIME_COST", validate_default=True)
+    password_hash_memory_cost: int = Field(default=65536, alias="PASSWORD_HASH_MEMORY_COST", validate_default=True)
+    password_hash_parallelism: int = Field(default=4, alias="PASSWORD_HASH_PARALLELISM", validate_default=True)
     port: int = Field(default=8000, alias="PORT", validate_default=True)
 
     @field_validator("port", mode="before")
@@ -23,6 +24,19 @@ class Settings(BaseSettings):
             raise ValueError("PORT must be greater than 0")
 
         return port
+
+    @field_validator("password_hash_time_cost", "password_hash_memory_cost", "password_hash_parallelism", mode="before")
+    @classmethod
+    def validate_password_hash_setting(cls, value: object) -> int:
+        try:
+            parsed_value = int(value)
+        except (TypeError, ValueError) as err:
+            raise ValueError("password hash settings must be valid integers") from err
+
+        if parsed_value <= 0:
+            raise ValueError("password hash settings must be greater than 0")
+
+        return parsed_value
 
 
 def get_settings() -> Settings:

--- a/auth/app/schemas.py
+++ b/auth/app/schemas.py
@@ -1,15 +1,32 @@
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+from app.security import MIN_PASSWORD_LENGTH, validate_login_identifier, validate_password_strength, validate_username
 
 
 class RegistrationRequest(BaseModel):
     username: str = Field(min_length=3, max_length=50)
     email: EmailStr
-    password: str = Field(min_length=8, max_length=128)
+    password: str = Field(min_length=MIN_PASSWORD_LENGTH, max_length=128)
+
+    @field_validator("username")
+    @classmethod
+    def validate_username_field(cls, value: str) -> str:
+        return validate_username(value)
+
+    @field_validator("password")
+    @classmethod
+    def validate_password_field(cls, value: str) -> str:
+        return validate_password_strength(value)
 
 
 class LoginRequest(BaseModel):
     username_or_email: str = Field(min_length=3, max_length=255)
-    password: str = Field(min_length=8, max_length=128)
+    password: str = Field(min_length=MIN_PASSWORD_LENGTH, max_length=128)
+
+    @field_validator("username_or_email")
+    @classmethod
+    def validate_username_or_email_field(cls, value: str) -> str:
+        return validate_login_identifier(value)
 
 
 class APIMessage(BaseModel):

--- a/auth/app/security.py
+++ b/auth/app/security.py
@@ -1,0 +1,64 @@
+import re
+from functools import lru_cache
+
+from argon2 import PasswordHasher
+from argon2.exceptions import InvalidHashError, VerificationError, VerifyMismatchError
+
+from app.config import get_settings
+
+
+_USERNAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
+_MIN_LOGIN_IDENTIFIER_LENGTH = 3
+MIN_PASSWORD_LENGTH = 15
+
+
+@lru_cache
+def get_password_hasher() -> PasswordHasher:
+    # Build the configured Argon2 hasher once per process so password checks
+    # reuse the same validated settings instead of recreating the object.
+    settings = get_settings()
+    return PasswordHasher(
+        time_cost=settings.password_hash_time_cost,
+        memory_cost=settings.password_hash_memory_cost,
+        parallelism=settings.password_hash_parallelism,
+    )
+
+
+def validate_username(username: str) -> str:
+    normalized = username.strip().lower()
+
+    if len(normalized) < _MIN_LOGIN_IDENTIFIER_LENGTH:
+        raise ValueError(f"username must be at least {_MIN_LOGIN_IDENTIFIER_LENGTH} characters long")
+
+    if not _USERNAME_PATTERN.fullmatch(normalized):
+        raise ValueError("username may only contain letters, numbers, and underscores")
+
+    return normalized
+
+
+def validate_password_strength(password: str) -> str:
+    # Intentionally avoid composition rules here. NIST SP 800-63B and OWASP
+    # recommend length-based password validation plus blocklist checks instead
+    # of requirements like "must include uppercase/lowercase/number". The
+    # minimum length is enforced at the schema layer; this hook remains as the
+    # place for future password checks such as compromised-password blocklists.
+    return password
+
+
+def validate_login_identifier(identifier: str) -> str:
+    normalized = identifier.strip().lower()
+    if len(normalized) < _MIN_LOGIN_IDENTIFIER_LENGTH:
+        raise ValueError(f"username_or_email must be at least {_MIN_LOGIN_IDENTIFIER_LENGTH} characters long")
+
+    return normalized
+
+
+def hash_password(password: str) -> str:
+    return get_password_hasher().hash(password)
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    try:
+        return get_password_hasher().verify(password_hash, password)
+    except (InvalidHashError, VerificationError, VerifyMismatchError):
+        return False

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -6,3 +6,4 @@ psycopg[binary]==3.2.9
 pytest==8.4.1
 httpx==0.28.1
 email-validator==2.2.0
+argon2-cffi==25.1.0

--- a/auth/tests/test_config.py
+++ b/auth/tests/test_config.py
@@ -7,24 +7,36 @@ from app.config import get_settings
 def test_get_settings_uses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("APP_NAME", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("PASSWORD_HASH_TIME_COST", raising=False)
+    monkeypatch.delenv("PASSWORD_HASH_MEMORY_COST", raising=False)
+    monkeypatch.delenv("PASSWORD_HASH_PARALLELISM", raising=False)
     monkeypatch.delenv("PORT", raising=False)
 
     settings = get_settings()
 
     assert settings.app_name == "lineup-lab-auth"
     assert settings.database_url is None
+    assert settings.password_hash_time_cost == 3
+    assert settings.password_hash_memory_cost == 65536
+    assert settings.password_hash_parallelism == 4
     assert settings.port == 8000
 
 
 def test_get_settings_reads_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("APP_NAME", "test-auth")
     monkeypatch.setenv("DATABASE_URL", "postgres://user:pass@postgres/example")
+    monkeypatch.setenv("PASSWORD_HASH_TIME_COST", "2")
+    monkeypatch.setenv("PASSWORD_HASH_MEMORY_COST", "32768")
+    monkeypatch.setenv("PASSWORD_HASH_PARALLELISM", "2")
     monkeypatch.setenv("PORT", "9000")
 
     settings = get_settings()
 
     assert settings.app_name == "test-auth"
     assert settings.database_url == "postgres://user:pass@postgres/example"
+    assert settings.password_hash_time_cost == 2
+    assert settings.password_hash_memory_cost == 32768
+    assert settings.password_hash_parallelism == 2
     assert settings.port == 9000
 
 
@@ -39,4 +51,11 @@ def test_get_settings_rejects_non_positive_port(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv("PORT", "0")
 
     with pytest.raises(ValidationError, match="PORT must be greater than 0"):
+        get_settings()
+
+
+def test_get_settings_rejects_invalid_password_hash_setting(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PASSWORD_HASH_MEMORY_COST", "invalid")
+
+    with pytest.raises(ValidationError, match="password hash settings must be valid integers"):
         get_settings()

--- a/auth/tests/test_main.py
+++ b/auth/tests/test_main.py
@@ -26,7 +26,7 @@ def test_auth_routes_are_reserved() -> None:
         json={
             "username": "testuser",
             "email": "test@example.com",
-            "password": "supersecret",
+            "password": "correct horse battery",
         },
     )
 
@@ -34,12 +34,25 @@ def test_auth_routes_are_reserved() -> None:
     assert response.json() == {"detail": "registration is not implemented yet"}
 
 
+def test_register_route_rejects_short_passwords_before_handler() -> None:
+    response = client.post(
+        "/auth/register",
+        json={
+            "username": "testuser",
+            "email": "test@example.com",
+            "password": "short pass",
+        },
+    )
+
+    assert response.status_code == 422
+
+
 def test_login_route_is_reserved() -> None:
     response = client.post(
         "/auth/login",
         json={
             "username_or_email": "testuser",
-            "password": "supersecret",
+            "password": "correct horse battery",
         },
     )
 

--- a/auth/tests/test_schemas.py
+++ b/auth/tests/test_schemas.py
@@ -1,0 +1,58 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas import LoginRequest, RegistrationRequest
+
+
+def test_registration_request_accepts_valid_credentials() -> None:
+    request = RegistrationRequest(
+        username=" Test_User ",
+        email="test@example.com",
+        password="correct horse battery",
+    )
+
+    assert request.username == "test_user"
+    assert request.email == "test@example.com"
+    assert request.password == "correct horse battery"
+
+
+@pytest.mark.parametrize(
+    ("username", "error_message"),
+    [
+        (" a ", "username must be at least 3 characters long"),
+        ("test-user", "username may only contain letters, numbers, and underscores"),
+    ],
+)
+def test_registration_request_rejects_invalid_usernames(username: str, error_message: str) -> None:
+    with pytest.raises(ValidationError, match=error_message):
+        RegistrationRequest(
+            username=username,
+            email="test@example.com",
+            password="correct horse battery",
+        )
+
+
+def test_registration_request_rejects_passwords_shorter_than_nist_minimum() -> None:
+    with pytest.raises(ValidationError, match="at least 15 characters"):
+        RegistrationRequest(
+            username="test_user",
+            email="test@example.com",
+            password="short pass",
+        )
+
+
+def test_login_request_trims_identifier() -> None:
+    request = LoginRequest(
+        username_or_email=" Test@Example.com ",
+        password="correct horse battery",
+    )
+
+    assert request.username_or_email == "test@example.com"
+
+
+def test_login_request_rejects_too_short_identifier_after_trimming() -> None:
+    with pytest.raises(ValidationError, match="username_or_email must be at least 3 characters long"):
+        LoginRequest(
+            username_or_email="  a ",
+            password="correct horse battery",
+        )

--- a/auth/tests/test_security.py
+++ b/auth/tests/test_security.py
@@ -1,0 +1,27 @@
+from app.security import hash_password, verify_password
+
+
+def test_hash_password_uses_argon2_hash() -> None:
+    password_hash = hash_password("Supersecret1")
+
+    assert password_hash.startswith("$argon2id$")
+    assert password_hash != "Supersecret1"
+
+
+def test_verify_password_accepts_matching_password() -> None:
+    password_hash = hash_password("Supersecret1")
+
+    assert verify_password("Supersecret1", password_hash) is True
+
+
+def test_hash_password_allows_whitespace_characters() -> None:
+    password_hash = hash_password(" Super secret 1A ")
+
+    assert verify_password(" Super secret 1A ", password_hash) is True
+
+
+def test_verify_password_rejects_wrong_password_or_invalid_hash() -> None:
+    password_hash = hash_password("Supersecret1")
+
+    assert verify_password("WrongPassword1", password_hash) is False
+    assert verify_password("Supersecret1", "not-a-real-hash") is False


### PR DESCRIPTION
## Summary
- add Argon2 password hashing and verification helpers to the auth service
- enforce username and password validation in auth request schemas
- add auth tests for hashing, password strength, username validation, and login identifier normalization
- document the new auth security building blocks

## Verification
- `docker run --rm -v "$PWD:/workspace" -w /workspace/auth python:3.12-slim sh -lc "pip install --no-cache-dir -r requirements.txt >/tmp/pip.log && PYTHONPATH=/workspace/auth pytest tests -q"`
- `docker run --rm -v "$PWD:/workspace" -w /workspace/auth python:3.12-slim sh -lc "pip install --no-cache-dir ruff >/tmp/pip.log && ruff check app tests"`

Closes #31