### PR TITLE
auth: implement session-backed auth endpoints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,3 +115,4 @@ Before merging, check:
 - Avoid direct commits to `main`.
 - Keep the project runnable locally while improving the Kubernetes path.
 - Favor simple, explainable architecture choices over premature platform complexity.
+- Do not add `from __future__ import annotations` in new or edited files unless a maintainer explicitly asks for it.

--- a/auth/README.md
+++ b/auth/README.md
@@ -9,7 +9,8 @@ Current scope:
 - Argon2-based password hashing helpers and credential validation
   - configurable hash cost settings for auth environments
   - length-based password validation aligned with NIST/OWASP-style guidance
-- placeholder auth and user routes that reserve the public API shape
+- session-backed auth routes for registration, login, logout, and current-user lookup
+- secure cookie helpers for session and CSRF handling
 
 Ownership:
 - `auth` owns the `users` and `sessions` tables

--- a/auth/app/auth_service.py
+++ b/auth/app/auth_service.py
@@ -1,0 +1,112 @@
+from datetime import UTC, datetime
+from ipaddress import ip_address
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy import or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models import SessionRecord, User
+from app.schemas import LoginRequest, RegistrationRequest
+from app.security import hash_password, verify_password
+from app.session import new_session_expiry, new_session_id
+
+
+def register_user(db: Session, payload: RegistrationRequest) -> User:
+    existing_user = db.scalar(
+        select(User).where(or_(User.username == payload.username, User.email == payload.email))
+    )
+    if existing_user is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="username or email is already registered",
+        )
+
+    user = User(
+        username=payload.username,
+        email=payload.email,
+        password_hash=hash_password(payload.password),
+    )
+    db.add(user)
+    try:
+        db.commit()
+    except IntegrityError as err:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="username or email is already registered",
+        ) from err
+    db.refresh(user)
+    return user
+
+
+def login_user(db: Session, payload: LoginRequest, user_agent: str | None, client_ip: str | None) -> tuple[User, SessionRecord]:
+    user = db.scalar(
+        select(User).where(or_(User.username == payload.username_or_email, User.email == payload.username_or_email))
+    )
+    if user is None or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid username/email or password",
+        )
+
+    session = SessionRecord(
+        id=new_session_id(),
+        user_id=user.id,
+        expires_at=new_session_expiry(),
+        user_agent=user_agent,
+        ip_address=normalize_ip_address(client_ip),
+    )
+    user.last_login_at = datetime.now(UTC)
+    db.add(session)
+    db.commit()
+    db.refresh(user)
+    db.refresh(session)
+    return user, session
+
+
+def revoke_session(db: Session, session_id: UUID) -> SessionRecord:
+    now = datetime.now(UTC)
+    session = require_active_session(db, session_id, persist_last_seen=False)
+    session.last_seen_at = now
+    session.revoked_at = now
+    db.commit()
+    db.refresh(session)
+    return session
+
+
+def require_current_user(db: Session, session_id: UUID) -> User:
+    session = require_active_session(db, session_id)
+    user = db.get(User, session.user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="authentication required")
+
+    return user
+
+
+def require_active_session(db: Session, session_id: UUID, *, persist_last_seen: bool = True) -> SessionRecord:
+    session = db.get(SessionRecord, session_id)
+    if session is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="authentication required")
+
+    now = datetime.now(UTC)
+    if session.revoked_at is not None or session.expires_at <= now:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="authentication required")
+
+    if persist_last_seen:
+        session.last_seen_at = now
+        db.commit()
+        db.refresh(session)
+
+    return session
+
+
+def normalize_ip_address(value: str | None) -> str | None:
+    if value is None or not value.strip():
+        return None
+
+    try:
+        return str(ip_address(value.strip()))
+    except ValueError:
+        return None

--- a/auth/app/config.py
+++ b/auth/app/config.py
@@ -10,6 +10,11 @@ class Settings(BaseSettings):
     password_hash_time_cost: int = Field(default=3, alias="PASSWORD_HASH_TIME_COST", validate_default=True)
     password_hash_memory_cost: int = Field(default=65536, alias="PASSWORD_HASH_MEMORY_COST", validate_default=True)
     password_hash_parallelism: int = Field(default=4, alias="PASSWORD_HASH_PARALLELISM", validate_default=True)
+    session_cookie_name: str = Field(default="lineup_lab_session", alias="SESSION_COOKIE_NAME")
+    csrf_cookie_name: str = Field(default="lineup_lab_csrf", alias="CSRF_COOKIE_NAME")
+    session_ttl_seconds: int = Field(default=1_209_600, alias="SESSION_TTL_SECONDS", validate_default=True)
+    session_cookie_secure: bool = Field(default=False, alias="SESSION_COOKIE_SECURE", validate_default=True)
+    session_hmac_secret: str = Field(alias="SESSION_HMAC_SECRET")
     port: int = Field(default=8000, alias="PORT", validate_default=True)
 
     @field_validator("port", mode="before")
@@ -37,6 +42,52 @@ class Settings(BaseSettings):
             raise ValueError("password hash settings must be greater than 0")
 
         return parsed_value
+
+    @field_validator("session_ttl_seconds", mode="before")
+    @classmethod
+    def validate_session_ttl_seconds(cls, value: object) -> int:
+        try:
+            parsed_value = int(value)
+        except (TypeError, ValueError) as err:
+            raise ValueError("SESSION_TTL_SECONDS must be a valid integer") from err
+
+        if parsed_value <= 0:
+            raise ValueError("SESSION_TTL_SECONDS must be greater than 0")
+
+        return parsed_value
+
+    @field_validator("session_cookie_secure", mode="before")
+    @classmethod
+    def validate_session_cookie_secure(cls, value: object) -> bool:
+        if isinstance(value, bool):
+            return value
+
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "off"}:
+                return False
+
+        raise ValueError("SESSION_COOKIE_SECURE must be a valid boolean")
+
+    @field_validator("session_cookie_name", "csrf_cookie_name")
+    @classmethod
+    def validate_cookie_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("cookie names must not be empty")
+
+        return normalized
+
+    @field_validator("session_hmac_secret")
+    @classmethod
+    def validate_session_hmac_secret(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("SESSION_HMAC_SECRET must not be empty")
+
+        return normalized
 
 
 def get_settings() -> Settings:

--- a/auth/app/main.py
+++ b/auth/app/main.py
@@ -1,18 +1,30 @@
-from __future__ import annotations
-
 import logging
+from uuid import UUID
 
-from fastapi import FastAPI, Response, status
+from fastapi import Cookie, Depends, FastAPI, Header, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
 
+from app.auth_service import login_user, register_user, require_current_user, revoke_session
 from app.config import get_settings
-from app.db import is_database_ready
-from app.schemas import APIMessage, LoginRequest, RegistrationRequest
+from app.db import get_db, is_database_ready
+from app.schemas import APIMessage, LoginRequest, RegistrationRequest, UserResponse
+from app.session import clear_auth_cookies, is_valid_csrf_token, new_csrf_token, set_auth_cookies
 
 
 settings = get_settings()
 app = FastAPI(title=settings.app_name)
 logger = logging.getLogger(__name__)
+
+
+def require_session_id(session_cookie: str | None) -> UUID:
+    if session_cookie is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="authentication required")
+
+    try:
+        return UUID(session_cookie)
+    except ValueError as err:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="authentication required") from err
 
 
 @app.get("/healthz", status_code=status.HTTP_200_OK)
@@ -28,21 +40,46 @@ def readyz() -> Response:
     return JSONResponse(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content={"detail": "database is not ready"})
 
 
-@app.post("/auth/register", status_code=status.HTTP_501_NOT_IMPLEMENTED, response_model=APIMessage)
-def register(_: RegistrationRequest) -> APIMessage:
-    return APIMessage(detail="registration is not implemented yet")
+@app.post("/auth/register", status_code=status.HTTP_201_CREATED, response_model=UserResponse)
+def register(payload: RegistrationRequest, db: Session = Depends(get_db)) -> UserResponse:
+    user = register_user(db, payload)
+    return UserResponse(id=user.id, username=user.username, email=user.email)
 
 
-@app.post("/auth/login", status_code=status.HTTP_501_NOT_IMPLEMENTED, response_model=APIMessage)
-def login(_: LoginRequest) -> APIMessage:
-    return APIMessage(detail="login is not implemented yet")
+@app.post("/auth/login", status_code=status.HTTP_200_OK, response_model=UserResponse)
+def login(payload: LoginRequest, request: Request, response: Response, db: Session = Depends(get_db)) -> UserResponse:
+    client_ip = request.client.host if request.client is not None else None
+    user, session = login_user(db, payload, request.headers.get("user-agent"), client_ip)
+    csrf_token = new_csrf_token(session.id)
+    set_auth_cookies(response, session.id, csrf_token)
+    return UserResponse(id=user.id, username=user.username, email=user.email)
 
 
-@app.post("/auth/logout", status_code=status.HTTP_501_NOT_IMPLEMENTED, response_model=APIMessage)
-def logout() -> APIMessage:
-    return APIMessage(detail="logout is not implemented yet")
+@app.post("/auth/logout", status_code=status.HTTP_200_OK, response_model=APIMessage)
+def logout(
+    response: Response,
+    db: Session = Depends(get_db),
+    session_cookie: str | None = Cookie(default=None, alias=settings.session_cookie_name),
+    csrf_cookie: str | None = Cookie(default=None, alias=settings.csrf_cookie_name),
+    csrf_header: str | None = Header(default=None, alias="X-CSRF-Token"),
+) -> APIMessage:
+    if csrf_cookie is None or csrf_header is None or csrf_cookie != csrf_header:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="csrf token is invalid")
+
+    session_id = require_session_id(session_cookie)
+    if not is_valid_csrf_token(session_id, csrf_cookie):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="csrf token is invalid")
+
+    revoke_session(db, session_id)
+    clear_auth_cookies(response)
+    return APIMessage(detail="logout succeeded")
 
 
-@app.get("/users/me", status_code=status.HTTP_501_NOT_IMPLEMENTED, response_model=APIMessage)
-def me() -> APIMessage:
-    return APIMessage(detail="current user lookup is not implemented yet")
+@app.get("/users/me", status_code=status.HTTP_200_OK, response_model=UserResponse)
+def me(
+    db: Session = Depends(get_db),
+    session_cookie: str | None = Cookie(default=None, alias=settings.session_cookie_name),
+) -> UserResponse:
+    session_id = require_session_id(session_cookie)
+    user = require_current_user(db, session_id)
+    return UserResponse(id=user.id, username=user.username, email=user.email)

--- a/auth/app/schemas.py
+++ b/auth/app/schemas.py
@@ -13,6 +13,11 @@ class RegistrationRequest(BaseModel):
     def validate_username_field(cls, value: str) -> str:
         return validate_username(value)
 
+    @field_validator("email")
+    @classmethod
+    def normalize_email_field(cls, value: EmailStr) -> str:
+        return str(value).strip().lower()
+
     @field_validator("password")
     @classmethod
     def validate_password_field(cls, value: str) -> str:
@@ -31,3 +36,9 @@ class LoginRequest(BaseModel):
 
 class APIMessage(BaseModel):
     detail: str
+
+
+class UserResponse(BaseModel):
+    id: int
+    username: str
+    email: EmailStr

--- a/auth/app/session.py
+++ b/auth/app/session.py
@@ -1,0 +1,82 @@
+from base64 import urlsafe_b64encode
+from datetime import UTC, datetime, timedelta
+import hashlib
+import hmac
+import secrets
+import uuid
+
+from fastapi import Response
+
+from app.config import get_settings
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def new_session_expiry(now: datetime | None = None) -> datetime:
+    reference = now or utc_now()
+    return reference + timedelta(seconds=get_settings().session_ttl_seconds)
+
+
+def new_session_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+def new_csrf_token(session_id: uuid.UUID) -> str:
+    nonce = secrets.token_urlsafe(24)
+    return new_signed_csrf_token(str(session_id), nonce)
+
+
+def is_valid_csrf_token(session_id: uuid.UUID, csrf_token: str) -> bool:
+    try:
+        payload_session_id, nonce, encoded_signature = csrf_token.split(":", 2)
+    except ValueError:
+        return False
+
+    if payload_session_id != str(session_id) or not nonce or not encoded_signature:
+        return False
+
+    expected_token = new_signed_csrf_token(payload_session_id, nonce)
+    return hmac.compare_digest(expected_token, csrf_token)
+
+
+def new_signed_csrf_token(session_id: str, nonce: str) -> str:
+    settings = get_settings()
+    payload = f"{session_id}:{nonce}"
+    signature = hmac.new(
+        settings.session_hmac_secret.encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    encoded_signature = urlsafe_b64encode(signature).decode("ascii")
+    return f"{payload}:{encoded_signature}"
+
+
+def set_auth_cookies(response: Response, session_id: uuid.UUID, csrf_token: str) -> None:
+    settings = get_settings()
+
+    response.set_cookie(
+        key=settings.session_cookie_name,
+        value=str(session_id),
+        max_age=settings.session_ttl_seconds,
+        httponly=True,
+        secure=settings.session_cookie_secure,
+        samesite="lax",
+        path="/",
+    )
+    response.set_cookie(
+        key=settings.csrf_cookie_name,
+        value=csrf_token,
+        max_age=settings.session_ttl_seconds,
+        httponly=False,
+        secure=settings.session_cookie_secure,
+        samesite="lax",
+        path="/",
+    )
+
+
+def clear_auth_cookies(response: Response) -> None:
+    settings = get_settings()
+    response.delete_cookie(key=settings.session_cookie_name, path="/")
+    response.delete_cookie(key=settings.csrf_cookie_name, path="/")

--- a/auth/tests/conftest.py
+++ b/auth/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+
+os.environ.setdefault("SESSION_HMAC_SECRET", "test-session-secret")

--- a/auth/tests/test_config.py
+++ b/auth/tests/test_config.py
@@ -10,6 +10,11 @@ def test_get_settings_uses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PASSWORD_HASH_TIME_COST", raising=False)
     monkeypatch.delenv("PASSWORD_HASH_MEMORY_COST", raising=False)
     monkeypatch.delenv("PASSWORD_HASH_PARALLELISM", raising=False)
+    monkeypatch.delenv("SESSION_COOKIE_NAME", raising=False)
+    monkeypatch.delenv("CSRF_COOKIE_NAME", raising=False)
+    monkeypatch.delenv("SESSION_TTL_SECONDS", raising=False)
+    monkeypatch.delenv("SESSION_COOKIE_SECURE", raising=False)
+    monkeypatch.setenv("SESSION_HMAC_SECRET", "test-session-secret")
     monkeypatch.delenv("PORT", raising=False)
 
     settings = get_settings()
@@ -19,6 +24,11 @@ def test_get_settings_uses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.password_hash_time_cost == 3
     assert settings.password_hash_memory_cost == 65536
     assert settings.password_hash_parallelism == 4
+    assert settings.session_cookie_name == "lineup_lab_session"
+    assert settings.csrf_cookie_name == "lineup_lab_csrf"
+    assert settings.session_ttl_seconds == 1_209_600
+    assert settings.session_cookie_secure is False
+    assert settings.session_hmac_secret == "test-session-secret"
     assert settings.port == 8000
 
 
@@ -28,6 +38,11 @@ def test_get_settings_reads_environment(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("PASSWORD_HASH_TIME_COST", "2")
     monkeypatch.setenv("PASSWORD_HASH_MEMORY_COST", "32768")
     monkeypatch.setenv("PASSWORD_HASH_PARALLELISM", "2")
+    monkeypatch.setenv("SESSION_COOKIE_NAME", "session_cookie")
+    monkeypatch.setenv("CSRF_COOKIE_NAME", "csrf_cookie")
+    monkeypatch.setenv("SESSION_TTL_SECONDS", "3600")
+    monkeypatch.setenv("SESSION_COOKIE_SECURE", "true")
+    monkeypatch.setenv("SESSION_HMAC_SECRET", "super-secret")
     monkeypatch.setenv("PORT", "9000")
 
     settings = get_settings()
@@ -37,6 +52,11 @@ def test_get_settings_reads_environment(monkeypatch: pytest.MonkeyPatch) -> None
     assert settings.password_hash_time_cost == 2
     assert settings.password_hash_memory_cost == 32768
     assert settings.password_hash_parallelism == 2
+    assert settings.session_cookie_name == "session_cookie"
+    assert settings.csrf_cookie_name == "csrf_cookie"
+    assert settings.session_ttl_seconds == 3600
+    assert settings.session_cookie_secure is True
+    assert settings.session_hmac_secret == "super-secret"
     assert settings.port == 9000
 
 
@@ -58,4 +78,25 @@ def test_get_settings_rejects_invalid_password_hash_setting(monkeypatch: pytest.
     monkeypatch.setenv("PASSWORD_HASH_MEMORY_COST", "invalid")
 
     with pytest.raises(ValidationError, match="password hash settings must be valid integers"):
+        get_settings()
+
+
+def test_get_settings_rejects_invalid_session_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SESSION_TTL_SECONDS", "0")
+
+    with pytest.raises(ValidationError, match="SESSION_TTL_SECONDS must be greater than 0"):
+        get_settings()
+
+
+def test_get_settings_rejects_invalid_session_cookie_secure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SESSION_COOKIE_SECURE", "sometimes")
+
+    with pytest.raises(ValidationError, match="SESSION_COOKIE_SECURE must be a valid boolean"):
+        get_settings()
+
+
+def test_get_settings_requires_session_hmac_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SESSION_HMAC_SECRET", raising=False)
+
+    with pytest.raises(ValidationError):
         get_settings()

--- a/auth/tests/test_main.py
+++ b/auth/tests/test_main.py
@@ -1,9 +1,28 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
 
 from app import main
 
 
 client = TestClient(main.app)
+
+
+@pytest.fixture(autouse=True)
+def override_db_dependency():
+    def fake_get_db():
+        yield object()
+
+    client.cookies.clear()
+    main.app.dependency_overrides[main.get_db] = fake_get_db
+    try:
+        yield
+    finally:
+        client.cookies.clear()
+        main.app.dependency_overrides.clear()
 
 
 def test_healthz() -> None:
@@ -20,7 +39,12 @@ def test_readyz_returns_503_without_database() -> None:
     assert response.json() == {"detail": "database is not ready"}
 
 
-def test_auth_routes_are_reserved() -> None:
+def test_register_route_returns_created_user(monkeypatch) -> None:
+    def fake_register_user(_db, _payload):
+        return SimpleNamespace(id=1, username="testuser", email="test@example.com")
+
+    monkeypatch.setattr(main, "register_user", fake_register_user)
+
     response = client.post(
         "/auth/register",
         json={
@@ -30,8 +54,27 @@ def test_auth_routes_are_reserved() -> None:
         },
     )
 
-    assert response.status_code == 501
-    assert response.json() == {"detail": "registration is not implemented yet"}
+    assert response.status_code == 201
+    assert response.json() == {"id": 1, "username": "testuser", "email": "test@example.com"}
+
+
+def test_register_route_normalizes_email_before_service_call(monkeypatch) -> None:
+    def fake_register_user(_db, payload):
+        assert payload.email == "test@example.com"
+        return SimpleNamespace(id=1, username="testuser", email=payload.email)
+
+    monkeypatch.setattr(main, "register_user", fake_register_user)
+
+    response = client.post(
+        "/auth/register",
+        json={
+            "username": "testuser",
+            "email": "Test@Example.com",
+            "password": "correct horse battery",
+        },
+    )
+
+    assert response.status_code == 201
 
 
 def test_register_route_rejects_short_passwords_before_handler() -> None:
@@ -47,7 +90,16 @@ def test_register_route_rejects_short_passwords_before_handler() -> None:
     assert response.status_code == 422
 
 
-def test_login_route_is_reserved() -> None:
+def test_login_route_sets_auth_and_csrf_cookies(monkeypatch) -> None:
+    session_id = uuid4()
+
+    def fake_login_user(_db, _payload, _user_agent, _client_ip):
+        user = SimpleNamespace(id=1, username="testuser", email="test@example.com")
+        session = SimpleNamespace(id=session_id)
+        return user, session
+
+    monkeypatch.setattr(main, "login_user", fake_login_user)
+
     response = client.post(
         "/auth/login",
         json={
@@ -56,15 +108,92 @@ def test_login_route_is_reserved() -> None:
         },
     )
 
-    assert response.status_code == 501
-    assert response.json() == {"detail": "login is not implemented yet"}
+    assert response.status_code == 200
+    assert response.json() == {"id": 1, "username": "testuser", "email": "test@example.com"}
+    assert main.settings.session_cookie_name in response.cookies
+    assert main.settings.csrf_cookie_name in response.cookies
 
 
-def test_logout_and_me_routes_are_reserved() -> None:
-    logout_response = client.post("/auth/logout")
-    me_response = client.get("/users/me")
+def test_login_route_rejects_invalid_credentials(monkeypatch) -> None:
+    def fake_login_user(_db, _payload, _user_agent, _client_ip):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid username/email or password")
 
-    assert logout_response.status_code == 501
-    assert logout_response.json() == {"detail": "logout is not implemented yet"}
-    assert me_response.status_code == 501
-    assert me_response.json() == {"detail": "current user lookup is not implemented yet"}
+    monkeypatch.setattr(main, "login_user", fake_login_user)
+
+    response = client.post(
+        "/auth/login",
+        json={
+            "username_or_email": "testuser",
+            "password": "correct horse battery",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "invalid username/email or password"}
+
+
+def test_logout_route_rejects_invalid_session_cookie() -> None:
+    local_client = TestClient(main.app)
+    local_client.cookies.set(main.settings.session_cookie_name, "not-a-uuid")
+    local_client.cookies.set(main.settings.csrf_cookie_name, "cookie-token")
+    response = local_client.post("/auth/logout", headers={"X-CSRF-Token": "cookie-token"})
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "authentication required"}
+
+
+def test_logout_route_requires_matching_csrf(monkeypatch) -> None:
+    session_id = str(uuid4())
+    local_client = TestClient(main.app)
+    local_client.cookies.set(main.settings.session_cookie_name, session_id)
+    local_client.cookies.set(main.settings.csrf_cookie_name, "wrong-cookie-token")
+    response = local_client.post("/auth/logout", headers={"X-CSRF-Token": "wrong-header-token"})
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "csrf token is invalid"}
+
+
+def test_logout_route_revokes_session_and_clears_cookies(monkeypatch) -> None:
+    session_id = uuid4()
+    csrf_token = main.new_csrf_token(session_id)
+
+    def fake_revoke_session(_db, actual_session_id):
+        assert actual_session_id == session_id
+        return SimpleNamespace(id=actual_session_id)
+
+    monkeypatch.setattr(main, "revoke_session", fake_revoke_session)
+
+    local_client = TestClient(main.app)
+    local_client.cookies.set(main.settings.session_cookie_name, str(session_id))
+    local_client.cookies.set(main.settings.csrf_cookie_name, csrf_token)
+    response = local_client.post("/auth/logout", headers={"X-CSRF-Token": csrf_token})
+
+    assert response.status_code == 200
+    assert response.json() == {"detail": "logout succeeded"}
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    assert any(f"{main.settings.session_cookie_name}=" in header for header in set_cookie_headers)
+    assert any(f"{main.settings.csrf_cookie_name}=" in header for header in set_cookie_headers)
+
+
+def test_me_route_returns_current_user(monkeypatch) -> None:
+    session_id = uuid4()
+
+    def fake_require_current_user(_db, actual_session_id):
+        assert actual_session_id == session_id
+        return SimpleNamespace(id=1, username="testuser", email="test@example.com")
+
+    monkeypatch.setattr(main, "require_current_user", fake_require_current_user)
+
+    local_client = TestClient(main.app)
+    local_client.cookies.set(main.settings.session_cookie_name, str(session_id))
+    response = local_client.get("/users/me")
+
+    assert response.status_code == 200
+    assert response.json() == {"id": 1, "username": "testuser", "email": "test@example.com"}
+
+
+def test_me_route_requires_authentication() -> None:
+    response = client.get("/users/me")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "authentication required"}

--- a/auth/tests/test_schemas.py
+++ b/auth/tests/test_schemas.py
@@ -7,7 +7,7 @@ from app.schemas import LoginRequest, RegistrationRequest
 def test_registration_request_accepts_valid_credentials() -> None:
     request = RegistrationRequest(
         username=" Test_User ",
-        email="test@example.com",
+        email="Test@Example.com",
         password="correct horse battery",
     )
 

--- a/auth/tests/test_session.py
+++ b/auth/tests/test_session.py
@@ -1,0 +1,16 @@
+from uuid import uuid4
+
+from app.session import is_valid_csrf_token, new_csrf_token
+
+
+def test_new_csrf_token_is_valid_for_matching_session() -> None:
+    session_id = uuid4()
+    csrf_token = new_csrf_token(session_id)
+
+    assert is_valid_csrf_token(session_id, csrf_token) is True
+
+
+def test_new_csrf_token_is_invalid_for_different_session() -> None:
+    csrf_token = new_csrf_token(uuid4())
+
+    assert is_valid_csrf_token(uuid4(), csrf_token) is False


### PR DESCRIPTION
Closes #30
Refs #32

## Summary
- implement registration, login, logout, and current-user routes in the auth service
- add session and CSRF cookie helpers for the session-backed auth flow
- add auth service helpers for registration, login, session lookup, and logout
- expand auth tests around config, cookies, CSRF, and route behavior
- record the repo rule to avoid new `from __future__ import annotations` usage

## Why
- the auth service already had route placeholders and password hashing support, but no actual login or session flow
- login/logout is not complete without the server-side session behavior captured in #32, so this PR implements the two issues together at the backend layer

## Impact
- backend auth routes now return real responses instead of `501 Not Implemented`
- login now sets session and CSRF cookies
- logout now validates CSRF and revokes the server-side session
- `/users/me` can resolve the current authenticated user from the session cookie

## Validation
- `PYTHONPATH=/workspace/auth pytest auth/tests -q` in a clean Python 3.12 container with `auth/requirements.txt`
