### PR TITLE
[codex] Keep users.updated_at in sync at the database layer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "auth/**"
       - "frontend/**"
+      - "postgres/**"
       - "simulation/**"
       - "stats/**"
       - ".github/workflows/test.yml"
@@ -14,12 +15,44 @@ on:
     paths:
       - "auth/**"
       - "frontend/**"
+      - "postgres/**"
       - "simulation/**"
       - "stats/**"
       - ".github/workflows/test.yml"
   workflow_dispatch:
 
 jobs:
+  postgres-schema-tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16.4
+        env:
+          POSTGRES_DB: lineup_lab_test
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d lineup_lab_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      - name: Verify users.updated_at trigger
+        env:
+          PGHOST: localhost
+          PGPORT: "5432"
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGDATABASE: postgres
+        run: bash postgres/tests/users_updated_at_trigger.sh
+
   auth-tests:
     runs-on: ubuntu-latest
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -16,6 +16,7 @@ Ownership:
 - other services should not write auth-domain tables directly
 - the shared Postgres instance does not change that logical ownership model
 - auth-owned schema changes should follow the shared migration strategy in [docs/adr/0003-shared-postgres-migration-strategy.md](../docs/adr/0003-shared-postgres-migration-strategy.md)
+- `users.updated_at` is maintained both by the ORM mapping and by a Postgres trigger so non-ORM writes stay consistent too
 
 See the architecture decision record:
 - [docs/adr/0002-auth-owns-users-and-sessions.md](../docs/adr/0002-auth-owns-users-and-sessions.md)

--- a/postgres/init-table.sql
+++ b/postgres/init-table.sql
@@ -34,7 +34,7 @@ CREATE TABLE users (
     CONSTRAINT users_email_unique UNIQUE (email)
 );
 
-CREATE OR REPLACE FUNCTION set_users_updated_at()
+CREATE OR REPLACE FUNCTION update_updated_at_column()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = NOW();
@@ -42,10 +42,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS users_set_updated_at ON users;
 CREATE TRIGGER users_set_updated_at
 BEFORE UPDATE ON users
 FOR EACH ROW
-EXECUTE FUNCTION set_users_updated_at();
+EXECUTE FUNCTION update_updated_at_column();
 
 -- Sessions are stored server-side. The application generates the UUID session ID
 -- and can revoke sessions without deleting the historical row immediately.

--- a/postgres/init-table.sql
+++ b/postgres/init-table.sql
@@ -34,6 +34,19 @@ CREATE TABLE users (
     CONSTRAINT users_email_unique UNIQUE (email)
 );
 
+CREATE OR REPLACE FUNCTION set_users_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER users_set_updated_at
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION set_users_updated_at();
+
 -- Sessions are stored server-side. The application generates the UUID session ID
 -- and can revoke sessions without deleting the historical row immediately.
 CREATE TABLE sessions (

--- a/postgres/migrations/20260414190000_auth_users_updated_at_trigger.sql
+++ b/postgres/migrations/20260414190000_auth_users_updated_at_trigger.sql
@@ -1,6 +1,6 @@
 -- owner: auth
 
-CREATE OR REPLACE FUNCTION set_users_updated_at()
+CREATE OR REPLACE FUNCTION update_updated_at_column()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = NOW();
@@ -8,7 +8,18 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER users_set_updated_at
-BEFORE UPDATE ON users
-FOR EACH ROW
-EXECUTE FUNCTION set_users_updated_at();
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'users'
+    ) THEN
+        DROP TRIGGER IF EXISTS users_set_updated_at ON users;
+        CREATE TRIGGER users_set_updated_at
+        BEFORE UPDATE ON users
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END;
+$$;

--- a/postgres/migrations/20260414190000_auth_users_updated_at_trigger.sql
+++ b/postgres/migrations/20260414190000_auth_users_updated_at_trigger.sql
@@ -1,0 +1,14 @@
+-- owner: auth
+
+CREATE OR REPLACE FUNCTION set_users_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER users_set_updated_at
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION set_users_updated_at();

--- a/postgres/tests/users_updated_at_trigger.sh
+++ b/postgres/tests/users_updated_at_trigger.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${PGHOST:=localhost}"
+: "${PGPORT:=5432}"
+: "${PGUSER:=postgres}"
+: "${PGPASSWORD:=postgres}"
+: "${PGDATABASE:=postgres}"
+
+export PGPASSWORD
+
+psql_admin=(psql -v ON_ERROR_STOP=1 -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE")
+bootstrap_db="lineup_lab_init_trigger_test"
+empty_db="lineup_lab_empty_migration_test"
+
+"${psql_admin[@]}" <<SQL
+DROP DATABASE IF EXISTS ${bootstrap_db};
+DROP DATABASE IF EXISTS ${empty_db};
+CREATE DATABASE ${bootstrap_db};
+CREATE DATABASE ${empty_db};
+SQL
+
+cleanup() {
+    "${psql_admin[@]}" <<SQL >/dev/null
+DROP DATABASE IF EXISTS ${bootstrap_db};
+DROP DATABASE IF EXISTS ${empty_db};
+SQL
+}
+
+trap cleanup EXIT
+
+psql_bootstrap=(psql -v ON_ERROR_STOP=1 -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$bootstrap_db")
+psql_empty=(psql -v ON_ERROR_STOP=1 -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$empty_db")
+
+"${psql_bootstrap[@]}" -f postgres/init-table.sql >/dev/null
+"${psql_bootstrap[@]}" -f postgres/migrations/20260414190000_auth_users_updated_at_trigger.sql >/dev/null
+"${psql_empty[@]}" -f postgres/migrations/20260414190000_auth_users_updated_at_trigger.sql >/dev/null
+
+"${psql_bootstrap[@]}" <<'SQL'
+INSERT INTO users (username, email, password_hash)
+VALUES ('testuser', 'before@example.com', 'argon2-hash');
+
+SELECT pg_sleep(1);
+
+UPDATE users
+SET email = 'after@example.com'
+WHERE username = 'testuser';
+
+DO $$
+DECLARE
+    created_ts TIMESTAMPTZ;
+    updated_ts TIMESTAMPTZ;
+BEGIN
+    SELECT created_at, updated_at
+    INTO created_ts, updated_ts
+    FROM users
+    WHERE username = 'testuser';
+
+    IF updated_ts <= created_ts THEN
+        RAISE EXCEPTION 'expected updated_at (%) to be later than created_at (%)', updated_ts, created_ts;
+    END IF;
+END;
+$$;
+SQL


### PR DESCRIPTION
## Summary
- add a Postgres trigger so `users.updated_at` changes on every update
- add a shared migration for the trigger under the auth owner
- document the database-level timestamp behavior in the auth README
- add a Postgres schema check in CI for the trigger behavior

Closes #92

## Verification
- validated the repo script against a temporary `postgres:16.4` container
- confirmed `updated_at` advances after an update while `created_at` remains unchanged
- CI now runs `postgres/tests/users_updated_at_trigger.sh` for `postgres/**` changes
