### PR TITLE
docs: separate agent and contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,38 +1,32 @@
-# Repository Instructions
+# Agent Instructions
 
-## Workflow
-
-- Start new work from the latest `origin/main` unless the user explicitly asks to stack on another branch.
-- Use one branch per issue when practical. Prefer branch names like `codex/issue-123-short-name`.
-- Keep pull requests small and focused. We usually keep PRs to fewer than three commits.
-- For review fixes or small cleanup on an existing PR, prefer amending the relevant commit and force-pushing with `--force-with-lease`.
-- Do not include fake issue references. If there is no related issue, omit the issue line from the commit message and PR body.
-
-## Commit Messages
-
-Use this format when there is a related issue:
-
-```text
-<area>: <short summary>
-
-- <detailed summary bullet>
-- <detailed summary bullet>
-
-#<issue number>
-```
-
-If there is no related issue, use the same format without the final issue line.
-
-## Pull Requests
-
-- Link the relevant issue in the PR body with `Closes #<issue>` or `Refs #<issue>`.
-- Include verification notes for tests, CI checks, or manual validation.
-- After opening or updating a PR, check the automated reviews from Codex and Gemini.
-- Not every review comment must be addressed. If a comment is intentionally deferred or rejected, reply on the thread with a clear reason and, when useful, link the tracking issue.
-- If a review comment identifies a real bug or missing test, update the PR and rerun the relevant checks before asking for merge.
+This file contains instructions for AI agents working in this repository.
+General contributor workflow, commit messages, and pull request expectations live
+in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Before Coding
 
-- Check for this `AGENTS.md` file and follow the nearest applicable instructions.
-- Inspect the relevant code and existing patterns before introducing new abstractions.
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) before changing files.
+- Start new work from the latest `origin/main` unless the user explicitly asks
+  to stack on another branch.
+- Inspect the relevant code and existing patterns before introducing new
+  abstractions.
 - Keep changes scoped to the issue unless the user explicitly expands the task.
+- Do not include fake issue references. If there is no related issue, omit the
+  issue line from the commit message and PR body.
+
+## Code Style
+
+- Do not add `from __future__ import annotations` in new or edited Python files
+  unless a maintainer explicitly asks for it.
+- Prefer existing local patterns over new abstractions.
+- Keep comments sparse and useful.
+
+## Pull Request Reviews
+
+- After opening or updating a PR, check the automated reviews from Codex and Gemini.
+- Not every review comment must be addressed. If a comment is intentionally
+  deferred or rejected, reply on the thread with a clear reason and, when useful,
+  link the tracking issue.
+- If a review comment identifies a real bug or missing test, update the PR and
+  rerun the relevant checks before asking for merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,4 +115,3 @@ Before merging, check:
 - Avoid direct commits to `main`.
 - Keep the project runnable locally while improving the Kubernetes path.
 - Favor simple, explainable architecture choices over premature platform complexity.
-- Do not add `from __future__ import annotations` in new or edited files unless a maintainer explicitly asks for it.


### PR DESCRIPTION
Refs #18

## Summary
- make `AGENTS.md` an agent-specific supplement to `CONTRIBUTING.md`
- keep general workflow, commit, and PR guidance in `CONTRIBUTING.md`
- move the no `from __future__ import annotations` rule into the agent guidance

## Verification
- docs-only change
