### PR TITLE
frontend: add session-backed auth UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.env
+*.log
+
+**/node_modules
+**/.pytest_cache
+**/__pycache__
+**/.venv
+**/venv
+
+frontend/dist
+frontend/coverage

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ POSTGRES_PASSWORD=change-me
 PGADMIN_DEFAULT_EMAIL=admin@admin.com
 PGADMIN_DEFAULT_PASSWORD=change-me
 
+AUTH_PORT=8000
+AUTH_DATABASE_URL=postgres://myuser:change-me@postgres/mydatabase?sslmode=disable
+SESSION_HMAC_SECRET=replace-with-a-long-random-local-secret
+SESSION_COOKIE_SECURE=false
+
 STATS_PORT=80
 STATS_HOST_PORT=8082
 STATS_DATABASE_URL=postgres://myuser:change-me@postgres/mydatabase?sslmode=disable

--- a/.github/workflows/compose-config.yml
+++ b/.github/workflows/compose-config.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/compose-config.yml"
       - "docker-compose.yml"
       - ".env.example"
+      - "auth/**"
       - "gateway/**"
       - "frontend/**"
       - "simulation/**"
@@ -17,6 +18,7 @@ on:
       - ".github/workflows/compose-config.yml"
       - "docker-compose.yml"
       - ".env.example"
+      - "auth/**"
       - "gateway/**"
       - "frontend/**"
       - "simulation/**"
@@ -32,11 +34,13 @@ jobs:
       POSTGRES_PASSWORD: change-me
       PGADMIN_DEFAULT_EMAIL: admin@admin.com
       PGADMIN_DEFAULT_PASSWORD: change-me
+      SESSION_HMAC_SECRET: test-session-secret
     steps:
       - uses: actions/checkout@v5
 
       - name: Render default Compose config
         run: |
+          AUTH_DATABASE_URL=postgres://myuser:change-me@postgres/mydatabase?sslmode=disable \
           STATS_DATABASE_URL=postgres://myuser:change-me@postgres/mydatabase?sslmode=disable \
           docker compose config --format json > compose-default.json
 
@@ -52,6 +56,7 @@ jobs:
           gateway_service = services["gateway"]
           db_service = services["postgres"]
           pgadmin_service = services["pgadmin"]
+          auth_service = services["auth"]
           stat_service = services["stats"]
           gateway_port = gateway_service["ports"][0]
           stat_port = services["stats"]["ports"][0]
@@ -59,11 +64,14 @@ jobs:
 
           assert gateway_service["build"]["context"].endswith("lineup-lab")
           assert gateway_service["build"]["dockerfile"] == "gateway/Dockerfile"
+          assert gateway_service["environment"]["AUTH_PORT"] == "8000"
           assert db_service["environment"]["POSTGRES_DB"] == "mydatabase"
           assert db_service["environment"]["POSTGRES_USER"] == "myuser"
           assert db_service["environment"]["POSTGRES_PASSWORD"] == "change-me"
           assert pgadmin_service["environment"]["PGADMIN_DEFAULT_EMAIL"] == "admin@admin.com"
           assert pgadmin_service["environment"]["PGADMIN_DEFAULT_PASSWORD"] == "change-me"
+          assert auth_service["environment"]["DATABASE_URL"] == "postgres://myuser:change-me@postgres/mydatabase?sslmode=disable"
+          assert auth_service["environment"]["SESSION_HMAC_SECRET"] == "test-session-secret"
           assert stat_service["environment"]["DATABASE_URL"] == "postgres://myuser:change-me@postgres/mydatabase?sslmode=disable"
           assert gateway_port["published"] == "8080"
           assert gateway_port["target"] == 80
@@ -75,6 +83,8 @@ jobs:
 
       - name: Render Compose config with overridden service ports
         run: |
+          AUTH_DATABASE_URL=postgres://myuser:change-me@postgres/mydatabase?sslmode=disable \
+          AUTH_PORT=18000 \
           STATS_DATABASE_URL=postgres://myuser:change-me@postgres/mydatabase?sslmode=disable \
           STATS_PORT=18080 \
           STATS_HOST_PORT=19082 \
@@ -94,6 +104,7 @@ jobs:
           gateway_service = services["gateway"]
           db_service = services["postgres"]
           pgadmin_service = services["pgadmin"]
+          auth_service = services["auth"]
           stat_service = services["stats"]
           simulation_service = services["simulation"]
           gateway_port = gateway_service["ports"][0]
@@ -102,6 +113,7 @@ jobs:
 
           assert gateway_service["build"]["context"].endswith("lineup-lab")
           assert gateway_service["build"]["dockerfile"] == "gateway/Dockerfile"
+          assert gateway_service["environment"]["AUTH_PORT"] == "18000"
           assert db_service["environment"]["POSTGRES_DB"] == "mydatabase"
           assert db_service["environment"]["POSTGRES_USER"] == "myuser"
           assert db_service["environment"]["POSTGRES_PASSWORD"] == "change-me"
@@ -109,6 +121,8 @@ jobs:
           assert pgadmin_service["environment"]["PGADMIN_DEFAULT_PASSWORD"] == "change-me"
           assert gateway_port["published"] == "8080"
           assert gateway_port["target"] == 80
+          assert auth_service["environment"]["PORT"] == "18000"
+          assert auth_service["environment"]["DATABASE_URL"] == "postgres://myuser:change-me@postgres/mydatabase?sslmode=disable"
           assert stat_service["environment"]["PORT"] == "18080"
           assert stat_service["environment"]["DATABASE_URL"] == "postgres://myuser:change-me@postgres/mydatabase?sslmode=disable"
           assert stat_port["published"] == "19082"
@@ -120,7 +134,8 @@ jobs:
 
       - name: Verify missing required env fails fast
         run: |
-          if docker compose config >/tmp/compose-missing-env.log 2>&1; then
+          if AUTH_DATABASE_URL=postgres://myuser:change-me@postgres/mydatabase?sslmode=disable \
+            docker compose config >/tmp/compose-missing-env.log 2>&1; then
             echo "docker compose config unexpectedly succeeded without required env vars"
             exit 1
           fi
@@ -136,6 +151,8 @@ jobs:
       PGADMIN_DEFAULT_EMAIL: admin@admin.com
       PGADMIN_DEFAULT_PASSWORD: change-me
       STATS_DATABASE_URL: postgres://myuser:change-me@postgres/mydatabase?sslmode=disable
+      AUTH_DATABASE_URL: postgres://myuser:change-me@postgres/mydatabase?sslmode=disable
+      SESSION_HMAC_SECRET: test-session-secret
       SIMULATION_DEBUG: "1"
     steps:
       - uses: actions/checkout@v5
@@ -195,6 +212,11 @@ jobs:
             echo "Unknown API path returned frontend HTML"
             exit 1
           fi
+
+      - name: Verify unauthenticated auth route is proxied
+        run: |
+          status="$(curl -s -o users-me.json -w '%{http_code}' http://localhost:8080/api/users/me)"
+          test "$status" = "401"
 
       - name: Tear down Docker Compose stack
         if: always()

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -16,4 +16,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,27 @@ services:
       context: .
       dockerfile: gateway/Dockerfile
     environment:
+      AUTH_PORT: ${AUTH_PORT:-8000}
       STATS_PORT: ${STATS_PORT:-80}
       SIMULATION_PORT: ${SIMULATION_PORT:-80}
     ports:
       - 8080:80
     depends_on:
+      - auth
       - stats
       - simulation
+
+  auth:
+    build:
+      context: .
+      dockerfile: auth/Dockerfile
+    environment:
+      PORT: ${AUTH_PORT:-8000}
+      DATABASE_URL: ${AUTH_DATABASE_URL:?AUTH_DATABASE_URL must be set}
+      SESSION_HMAC_SECRET: ${SESSION_HMAC_SECRET:?SESSION_HMAC_SECRET must be set}
+      SESSION_COOKIE_SECURE: ${SESSION_COOKIE_SECURE:-false}
+    depends_on:
+      - postgres
 
   simulation:
     build: ./simulation

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,12 +6,109 @@
     padding: 20px;
 }
 
+.app-header {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 24px;
+    padding: 16px 20px 0;
+    text-align: center;
+}
+
+.app-header h1 {
+    margin: 0;
+}
+
+.user-menu {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 0.95rem;
+}
+
 .card {
     background: white;
     border-radius: 8px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     padding: 20px;
     width: 450px;
+}
+
+.auth-layout {
+    display: flex;
+    justify-content: center;
+    padding: 20px;
+}
+
+.auth-card {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    width: min(420px, calc(100vw - 40px));
+    padding: 20px;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.auth-card label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-weight: 600;
+}
+
+.auth-card input {
+    padding: 10px;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+}
+
+.auth-card input:focus {
+    border-color: #007bff;
+    outline: none;
+    box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+}
+
+.auth-tabs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+}
+
+.auth-tabs button,
+.primary-button,
+.secondary-button {
+    min-height: 2.5rem;
+    padding: 0 14px;
+    border: 1px solid #007bff;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1rem;
+}
+
+.auth-tabs button,
+.secondary-button {
+    color: #007bff;
+    background: white;
+}
+
+.auth-tabs button.active,
+.primary-button {
+    color: white;
+    background: #007bff;
+}
+
+.auth-error {
+    margin: 0;
+    color: #b00020;
+}
+
+.auth-message,
+.session-status {
+    margin: 20px;
+    text-align: center;
 }
 
 .card h2 {
@@ -90,4 +187,16 @@
     border-color: #007bff;
     outline: none;
     box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+}
+
+@media (max-width: 980px) {
+    .app-header,
+    .container {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .card {
+        width: min(450px, calc(100vw - 40px));
+    }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,8 +6,71 @@ import Roster from './Roster.jsx';
 import './App.css';
 
 const apiBasePath = '/api';
+const csrfCookieName = 'lineup_lab_csrf';
+
+const readCookie = (name) => {
+  const prefix = `${name}=`;
+  const cookie = document.cookie
+    .split('; ')
+    .find(value => value.startsWith(prefix));
+
+  if (!cookie) {
+    return null;
+  }
+
+  const value = cookie.slice(prefix.length);
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const formatAPIErrorDetail = (detail) => {
+  if (typeof detail === 'string') {
+    return detail;
+  }
+
+  if (Array.isArray(detail)) {
+    return detail
+      .map(error => {
+        if (typeof error === 'string') {
+          return error;
+        }
+
+        if (error && typeof error === 'object' && typeof error.msg === 'string') {
+          return error.msg;
+        }
+
+        return 'Invalid input';
+      })
+      .join(' ');
+  }
+
+  return 'Request failed';
+};
+
+const parseAPIError = async (response) => {
+  try {
+    const payload = await response.json();
+    return formatAPIErrorDetail(payload.detail);
+  } catch {
+    return 'Request failed';
+  }
+};
 
 const App = () => {
+  const [currentUser, setCurrentUser] = useState(null);
+  const [authStatus, setAuthStatus] = useState('loading');
+  const [authMode, setAuthMode] = useState('login');
+  const [authForm, setAuthForm] = useState({
+    username: '',
+    email: '',
+    password: '',
+  });
+  const [authError, setAuthError] = useState('');
+  const [authMessage, setAuthMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [teams, setTeams] = useState([]);
   const [selectedTeam, setSelectedTeam] = useState('');
   const [players, setPlayers] = useState([]);
@@ -15,18 +78,61 @@ const App = () => {
   const [simulationResult, setSimulationResult] = useState(null);
 
   useEffect(() => {
-    fetch(`${apiBasePath}/teams`)
-      .then(response => response.json())
-      .then(data => setTeams(data))
-      .catch(error => console.error('Error fetching teams:', error));
+    fetch(`${apiBasePath}/users/me`, {
+      credentials: 'same-origin',
+    })
+      .then(async response => {
+        if (response.ok) {
+          const user = await response.json();
+          setCurrentUser(user);
+          setAuthStatus('authenticated');
+          return;
+        }
+
+        setCurrentUser(null);
+        setAuthStatus('anonymous');
+      })
+      .catch(error => {
+        console.error('Error checking session:', error);
+        setCurrentUser(null);
+        setAuthStatus('anonymous');
+      });
   }, []);
+
+  useEffect(() => {
+    if (authStatus !== 'authenticated') {
+      return;
+    }
+
+    fetch(`${apiBasePath}/teams`)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Failed to fetch teams');
+        }
+
+        return response.json();
+      })
+      .then(data => setTeams(Array.isArray(data) ? data : []))
+      .catch(error => console.error('Error fetching teams:', error));
+  }, [authStatus]);
 
   useEffect(() => {
     if (selectedTeam) {
       const [name, year] = selectedTeam.split('+');
       fetch(`${apiBasePath}/batting?team=${name}&year=${year}`)
-        .then(response => response.json())
+        .then(response => {
+          if (!response.ok) {
+            throw new Error('Failed to fetch roster');
+          }
+
+          return response.json();
+        })
         .then(data => {
+          if (!Array.isArray(data)) {
+            setPlayers([]);
+            return;
+          }
+
           // add AVG, OBP, SLG to the player data
           data.map(player => {
             player.avg = player.hit / player.at_bat;
@@ -96,25 +202,228 @@ const App = () => {
     setSimulationResult(result);
   };
 
+  const onAuthFormChange = (event) => {
+    const { name, value } = event.target;
+    setAuthForm(prevForm => ({
+      ...prevForm,
+      [name]: value,
+    }));
+  };
+
+  const resetWorkspace = () => {
+    setTeams([]);
+    setSelectedTeam('');
+    setPlayers([]);
+    setLineup(Array(9).fill(null));
+    setSimulationResult(null);
+  };
+
+  const loginWithCredentials = async (usernameOrEmail, password) => {
+    const response = await fetch(`${apiBasePath}/auth/login`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username_or_email: usernameOrEmail,
+        password,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(await parseAPIError(response));
+    }
+
+    return response.json();
+  };
+
+  const submitAuthForm = async (event) => {
+    event.preventDefault();
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setAuthError('');
+    setAuthMessage('');
+
+    try {
+      let user;
+      if (authMode === 'register') {
+        const response = await fetch(`${apiBasePath}/auth/register`, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            username: authForm.username,
+            email: authForm.email,
+            password: authForm.password,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(await parseAPIError(response));
+        }
+
+        user = await loginWithCredentials(authForm.username, authForm.password);
+      } else {
+        user = await loginWithCredentials(authForm.username, authForm.password);
+      }
+
+      setCurrentUser(user);
+      setAuthStatus('authenticated');
+      setAuthMessage('');
+      setAuthForm({
+        username: '',
+        email: '',
+        password: '',
+      });
+    } catch (error) {
+      setAuthError(error.message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const logout = async () => {
+    setAuthError('');
+    setAuthMessage('');
+
+    try {
+      const csrfToken = readCookie(csrfCookieName);
+      const response = await fetch(`${apiBasePath}/auth/logout`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'X-CSRF-Token': csrfToken || '',
+        },
+      });
+
+      if (!response.ok) {
+        setAuthError(await parseAPIError(response));
+        return;
+      }
+
+      setCurrentUser(null);
+      setAuthStatus('anonymous');
+      setAuthMessage('You have been logged out.');
+      resetWorkspace();
+    } catch {
+      setAuthError('Network error. Please try again.');
+    }
+  };
+
+  const switchAuthMode = (mode) => {
+    setAuthMode(mode);
+    setAuthError('');
+    setAuthMessage('');
+  };
+
   return (
     <DndProvider backend={HTML5Backend}>
-      <header style={{ textAlign: 'center' }}>
+      <header className="app-header">
         <h1>Lineup Lab</h1>
+        {currentUser && (
+          <div className="user-menu" aria-label="User session">
+            <span>Signed in as <strong>{currentUser.username}</strong></span>
+            <button type="button" className="secondary-button" onClick={logout}>Log out</button>
+          </div>
+        )}
       </header>
-      <div className="container">
-        <div className="card">
-          <Lineup
-            lineup={lineup}
-            movePlayerToSlot={movePlayerToSlot}
-            removePlayerFromSlot={removePlayerFromSlot}
-            simulateLineup={simulateLineup}
-            simulationResult={simulationResult}
-          />
+
+      {authStatus === 'loading' && (
+        <p className="session-status">Checking session...</p>
+      )}
+
+      {authStatus === 'authenticated' && authError && (
+        <p className="auth-error" role="alert">{authError}</p>
+      )}
+
+      {authStatus === 'anonymous' && (
+        <div className="auth-layout">
+          <form className="auth-card" onSubmit={submitAuthForm}>
+            <div className="auth-tabs" role="tablist" aria-label="Authentication mode">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={authMode === 'login'}
+                className={authMode === 'login' ? 'active' : ''}
+                onClick={() => switchAuthMode('login')}
+              >
+                Log in
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={authMode === 'register'}
+                className={authMode === 'register' ? 'active' : ''}
+                onClick={() => switchAuthMode('register')}
+              >
+                Register
+              </button>
+            </div>
+            <label>
+              {authMode === 'login' ? 'Username or email' : 'Username'}
+              <input
+                name="username"
+                value={authForm.username}
+                onChange={onAuthFormChange}
+                autoComplete={authMode === 'login' ? 'username' : 'username'}
+                required
+              />
+            </label>
+            {authMode === 'register' && (
+              <label>
+                Email
+                <input
+                  type="email"
+                  name="email"
+                  value={authForm.email}
+                  onChange={onAuthFormChange}
+                  autoComplete="email"
+                  required
+                />
+              </label>
+            )}
+            <label>
+              Password
+              <input
+                type="password"
+                name="password"
+                value={authForm.password}
+                onChange={onAuthFormChange}
+                autoComplete={authMode === 'login' ? 'current-password' : 'new-password'}
+                required
+              />
+            </label>
+            {authError && <p className="auth-error" role="alert">{authError}</p>}
+            {authMessage && <p className="auth-message">{authMessage}</p>}
+            <button type="submit" className="primary-button" disabled={isSubmitting}>
+              {isSubmitting ? 'Submitting...' : (authMode === 'login' ? 'Log in' : 'Create account')}
+            </button>
+          </form>
         </div>
-        <div className="card">
-          <Roster players={players} teams={teams} selectedTeam={selectedTeam} onTeamChange={onTeamChange} />
+      )}
+
+      {authStatus === 'authenticated' && (
+        <div className="container">
+          <div className="card">
+            <Lineup
+              lineup={lineup}
+              movePlayerToSlot={movePlayerToSlot}
+              removePlayerFromSlot={removePlayerFromSlot}
+              simulateLineup={simulateLineup}
+              simulationResult={simulationResult}
+            />
+          </div>
+          <div className="card">
+            <Roster players={players} teams={teams} selectedTeam={selectedTeam} onTeamChange={onTeamChange} />
+          </div>
         </div>
-      </div>
+      )}
     </DndProvider>
   );
 };

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -15,17 +15,29 @@ vi.mock('react-dnd-html5-backend', () => ({
 
 const createJSONResponse = (data) =>
   Promise.resolve({
+    ok: true,
+    status: 200,
     json: () => Promise.resolve(data),
   });
+
+const createErrorResponse = (status, data) =>
+  Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve(data),
+  });
+
+const currentUser = { id: 1, username: 'testuser', email: 'test@example.com' };
 
 describe('App', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    document.cookie = 'lineup_lab_csrf=; Max-Age=0; path=/';
   });
 
   it('renders the app header', async () => {
     global.fetch = vi.fn(() =>
-      createJSONResponse([])
+      createErrorResponse(401, { detail: 'authentication required' })
     );
 
     render(<App />);
@@ -34,25 +46,295 @@ describe('App', () => {
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
   });
 
-  it('loads teams on mount', async () => {
+  it('shows the login form when there is no active session', async () => {
     global.fetch = vi.fn(() =>
-      createJSONResponse([
-        { name: 'Yankees', year: 2024 },
-        { name: 'Mets', year: 2023 },
-      ])
+      createErrorResponse(401, { detail: 'authentication required' })
     );
+
+    render(<App />);
+
+    expect(await screen.findByRole('tab', { name: 'Log in' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument();
+    expect(screen.queryByText('Roster')).not.toBeInTheDocument();
+  });
+
+  it('logs in and loads protected workspace data', async () => {
+    const user = userEvent.setup();
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createErrorResponse(401, { detail: 'authentication required' })
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse(currentUser)
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse([
+          { name: 'Yankees', year: 2024 },
+        ])
+      );
+
+    render(<App />);
+
+    await user.type(await screen.findByLabelText('Username or email'), 'testuser');
+    await user.type(screen.getByLabelText('Password'), 'correct horse battery');
+    await user.click(screen.getByRole('button', { name: 'Log in' }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        '/api/auth/login',
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'same-origin',
+        })
+      );
+    });
+    expect(await screen.findByText(/Signed in as/)).toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'Yankees (2024)' })).toBeInTheDocument();
+  });
+
+  it('shows readable validation errors from the auth API', async () => {
+    const user = userEvent.setup();
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createErrorResponse(401, { detail: 'authentication required' })
+      )
+      .mockImplementationOnce(() =>
+        createErrorResponse(422, {
+          detail: [
+            { msg: 'Password must be at least 15 characters long' },
+            { msg: 'Username may only contain letters, numbers, and underscores' },
+          ],
+        })
+      );
+
+    render(<App />);
+
+    await user.type(await screen.findByLabelText('Username or email'), 'bad username');
+    await user.type(screen.getByLabelText('Password'), 'short');
+    await user.click(screen.getByRole('button', { name: 'Log in' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Password must be at least 15 characters long Username may only contain letters, numbers, and underscores'
+    );
+  });
+
+  it('prevents duplicate auth submissions while a request is in flight', async () => {
+    const user = userEvent.setup();
+    let resolveLogin;
+    const loginPromise = new Promise(resolve => {
+      resolveLogin = resolve;
+    });
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createErrorResponse(401, { detail: 'authentication required' })
+      )
+      .mockImplementationOnce(() =>
+        loginPromise
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse([])
+      );
+
+    render(<App />);
+
+    await user.type(await screen.findByLabelText('Username or email'), 'testuser');
+    await user.type(screen.getByLabelText('Password'), 'correct horse battery');
+    const submitButton = screen.getByRole('button', { name: 'Log in' });
+    await user.click(submitButton);
+    await user.click(screen.getByRole('button', { name: 'Submitting...' }));
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    resolveLogin(createJSONResponse(currentUser));
+    expect(await screen.findByText(/Signed in as/)).toBeInTheDocument();
+  });
+
+  it('registers a new user and signs in', async () => {
+    const user = userEvent.setup();
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createErrorResponse(401, { detail: 'authentication required' })
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse(currentUser)
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse(currentUser)
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse([])
+      );
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('tab', { name: 'Register' }));
+    await user.type(screen.getByLabelText('Username'), 'testuser');
+    await user.type(screen.getByLabelText('Email'), 'test@example.com');
+    await user.type(screen.getByLabelText('Password'), 'correct horse battery');
+    await user.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        '/api/auth/register',
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'same-origin',
+        })
+      );
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        3,
+        '/api/auth/login',
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'same-origin',
+        })
+      );
+    });
+    expect(await screen.findByText(/Signed in as/)).toBeInTheDocument();
+  });
+
+  it('logs out with the CSRF token and hides protected content', async () => {
+    const user = userEvent.setup();
+    document.cookie = 'lineup_lab_csrf=csrf-token; path=/';
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createJSONResponse(currentUser)
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse([])
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse({ detail: 'logout succeeded' })
+      );
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Log out' }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        3,
+        '/api/auth/logout',
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'X-CSRF-Token': 'csrf-token',
+          },
+        })
+      );
+    });
+    expect(await screen.findByText('You have been logged out.')).toBeInTheDocument();
+    expect(screen.queryByText('Roster')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the raw CSRF cookie value when decoding fails', async () => {
+    const user = userEvent.setup();
+    document.cookie = 'lineup_lab_csrf=raw%token; path=/';
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createJSONResponse(currentUser)
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse([])
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse({ detail: 'logout succeeded' })
+      );
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Log out' }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        3,
+        '/api/auth/logout',
+        expect.objectContaining({
+          headers: {
+            'X-CSRF-Token': 'raw%token',
+          },
+        })
+      );
+    });
+  });
+
+  it('shows a network error when logout cannot reach the auth API', async () => {
+    const user = userEvent.setup();
+    document.cookie = 'lineup_lab_csrf=csrf-token; path=/';
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createJSONResponse(currentUser)
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse([])
+      )
+      .mockImplementationOnce(() =>
+        Promise.reject(new Error('network down'))
+      );
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Log out' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Network error. Please try again.');
+    expect(screen.getByText(/Signed in as/)).toBeInTheDocument();
+  });
+
+  it('loads teams on mount', async () => {
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createJSONResponse(currentUser)
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse([
+          { name: 'Yankees', year: 2024 },
+          { name: 'Mets', year: 2023 },
+        ])
+      );
 
     render(<App />);
 
     expect(await screen.findByRole('option', { name: 'Yankees (2024)' })).toBeInTheDocument();
     expect(await screen.findByRole('option', { name: 'Mets (2023)' })).toBeInTheDocument();
-    expect(global.fetch).toHaveBeenCalledWith('/api/teams');
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      '/api/teams'
+    );
+  });
+
+  it('keeps teams empty when the teams API returns an error object', async () => {
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        createJSONResponse(currentUser)
+      )
+      .mockImplementationOnce(() =>
+        createJSONResponse({ detail: 'unexpected response' })
+      );
+
+    render(<App />);
+
+    expect(await screen.findByRole('combobox')).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Yankees/ })).not.toBeInTheDocument();
   });
 
   it('loads roster data after selecting a team', async () => {
     const user = userEvent.setup();
     global.fetch = vi
       .fn()
+      .mockImplementationOnce(() =>
+        createJSONResponse(currentUser)
+      )
       .mockImplementationOnce(() =>
         createJSONResponse([
           { name: 'Yankees', year: 2024 },
@@ -94,7 +376,7 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenNthCalledWith(
-        2,
+        3,
         '/api/batting?team=Yankees&year=2024'
       );
     });

--- a/gateway/default.conf
+++ b/gateway/default.conf
@@ -10,6 +10,16 @@ server {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
 
+  location ~ ^/api/auth/(.*)$ {
+    rewrite ^/api/auth/(.*)$ /auth/$1 break;
+    proxy_pass http://auth:${AUTH_PORT};
+  }
+
+  location ~ ^/api/users/(.*)$ {
+    rewrite ^/api/users/(.*)$ /users/$1 break;
+    proxy_pass http://auth:${AUTH_PORT};
+  }
+
   location ~ ^/api/teams/?$ {
     rewrite ^ /teams break;
     proxy_pass http://stats:${STATS_PORT};


### PR DESCRIPTION
## Summary
- add login, registration, logout, and session-check flows to the frontend
- protect the lineup workspace behind `/api/users/me` session state
- route `/api/auth/*` and `/api/users/*` through the gateway to the auth service
- add auth to local Docker Compose and Compose config validation
- add `.dockerignore` so root-context gateway/auth builds do not send local dependencies and caches

Closes #33

## Verification
- `npm run test` in `frontend`
- `npm run test:coverage` in `frontend`
- `npm run build` in `frontend`
- rendered default and overridden `docker compose config` with auth env values
- verified the missing required env check still isolates `STATS_DATABASE_URL`
- `docker compose up -d --build` completed after adding `.dockerignore`

## Notes
- Host-side curl checks against `localhost:8080` were inconsistent in this local sandbox after Docker Desktop rebuilt the stack. The Compose build itself succeeded, and CI now includes the gateway auth proxy smoke path for `/api/users/me`.
