### PR TITLE
security: add baseline XSS hardening

### DIFF
--- a/.github/workflows/compose-config.yml
+++ b/.github/workflows/compose-config.yml
@@ -161,6 +161,17 @@ jobs:
         run: |
           grep -F "<title>Lineup Lab</title>" gateway-root.html
 
+      - name: Verify gateway security headers
+        run: |
+          curl -fsSI http://localhost:8080/ > gateway-root.headers
+          grep -F "Content-Security-Policy:" gateway-root.headers
+          grep -F "default-src 'self'" gateway-root.headers
+          grep -F "script-src 'self'" gateway-root.headers
+          grep -F "object-src 'none'" gateway-root.headers
+          grep -F "frame-ancestors 'none'" gateway-root.headers
+          grep -F "X-Content-Type-Options: nosniff" gateway-root.headers
+          grep -F "Referrer-Policy: same-origin" gateway-root.headers
+
       - name: Wait for proxied teams endpoint
         run: |
           for attempt in $(seq 1 30); do

--- a/README.md
+++ b/README.md
@@ -197,5 +197,6 @@ The frontend coverage summary is written to `frontend/coverage/coverage-summary.
 - postgres bootstrap and migration notes: [postgres/README.md](postgres/README.md)
 - architecture decisions: [docs/adr/README.md](docs/adr/README.md)
 - auth session strategy: [docs/auth-session-strategy.md](docs/auth-session-strategy.md)
+- XSS hardening notes: [docs/xss-hardening.md](docs/xss-hardening.md)
 - local env template: [.env.example](.env.example)
 - contributor workflow: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/docs/auth-session-strategy.md
+++ b/docs/auth-session-strategy.md
@@ -50,6 +50,22 @@ Why these defaults:
 - `Secure=true` should be required in HTTPS deployments
 - host-only cookies keep the scope tight unless cross-subdomain sharing is truly needed
 
+## XSS Assumptions
+
+The session and CSRF model assumes the browser-facing app is also hardened
+against XSS. The session cookie is `HttpOnly`, but the CSRF cookie is readable by
+frontend JavaScript by design. If attacker-controlled JavaScript runs in the
+Lineup Lab origin, it may be able to read the CSRF cookie and make authenticated
+requests through the trusted frontend path.
+
+Baseline XSS mitigations are tracked in
+[docs/xss-hardening.md](xss-hardening.md). In short:
+
+- the gateway should send a conservative CSP and related browser security
+  headers
+- the frontend should avoid rendering untrusted HTML
+- future rich text or third-party script use must revisit the CSP explicitly
+
 ## CSRF Model
 
 CSRF matters because browsers send cookies automatically. Without an extra check, a third-party site may be able to trigger a state-changing request that still carries the victim's valid session cookie.
@@ -257,8 +273,9 @@ So the gateway should help establish identity, but `stat-api-server` should own 
 
 Current state:
 
-- `stat-api-server` and `game-simulation` do not enforce auth
-- `auth` routes are placeholders
+- `stats` and `simulation` do not enforce auth
+- `auth` implements session-backed registration, login, logout, and current-user
+  lookup
 
 Target state under epic `#18`:
 

--- a/docs/xss-hardening.md
+++ b/docs/xss-hardening.md
@@ -1,0 +1,72 @@
+# XSS Hardening
+
+This document records the baseline XSS mitigations for the gateway-routed
+browser app under `#104`.
+
+## Why It Matters
+
+The auth model uses an `HttpOnly` session cookie plus a readable CSRF cookie.
+That is a good browser-session shape, but it assumes the app also reduces XSS
+risk. If attacker-controlled JavaScript runs in the Lineup Lab origin, it may be
+able to read the CSRF cookie and perform authenticated actions through the
+trusted frontend path.
+
+XSS protection does not replace session validation, CSRF checks, or
+authorization. It limits the chance that attacker-controlled script can run in
+the first place.
+
+## Gateway Headers
+
+The gateway sets baseline browser security headers:
+
+- `Content-Security-Policy`
+- `X-Content-Type-Options`
+- `X-Frame-Options`
+- `Referrer-Policy`
+- `Cross-Origin-Opener-Policy`
+- `Cross-Origin-Resource-Policy`
+- `Permissions-Policy`
+
+The current CSP is intentionally conservative:
+
+```text
+default-src 'self';
+script-src 'self';
+style-src 'self';
+img-src 'self' data:;
+font-src 'self';
+connect-src 'self';
+object-src 'none';
+base-uri 'self';
+form-action 'self';
+frame-ancestors 'none';
+manifest-src 'self'
+```
+
+This policy allows the built frontend to load assets from the gateway origin and
+to call same-origin `/api/*` routes. It blocks inline scripts, third-party
+scripts, plugin/object embeds, and framing.
+
+## Frontend Rules
+
+The frontend should keep relying on React's default text escaping.
+
+Avoid these patterns unless a future PR adds a reviewed sanitizer and CSP update:
+
+- `dangerouslySetInnerHTML`
+- direct `innerHTML` assignment
+- `eval()` or `new Function()`
+- rendering untrusted URL/query/body values as HTML
+- adding third-party scripts without revisiting the CSP
+
+Rich text or user-authored HTML should be treated as a separate security design
+task, not a small rendering detail.
+
+## Current Frontend Check
+
+The current frontend source does not use obvious raw-HTML or dynamic-code
+patterns such as `dangerouslySetInnerHTML`, `innerHTML`, `eval()`, or
+`new Function()`.
+
+That scan is not a permanent guarantee. It is a baseline check that should be
+repeated when adding new rendering features or dependencies.

--- a/gateway/default.conf
+++ b/gateway/default.conf
@@ -10,6 +10,14 @@ server {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
 
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; manifest-src 'self'" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header Referrer-Policy "same-origin" always;
+  add_header Cross-Origin-Opener-Policy "same-origin" always;
+  add_header Cross-Origin-Resource-Policy "same-origin" always;
+  add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
+
   location ~ ^/api/teams/?$ {
     rewrite ^ /teams break;
     proxy_pass http://stats:${STATS_PORT};


### PR DESCRIPTION
## Summary
- add gateway CSP and browser security headers
- document XSS assumptions for session-backed auth
- add CI smoke checks for gateway security headers

## Validation
- git diff --check
- docker compose config --format json
- npm test
- npm run build
- docker compose gateway smoke check for security headers

Closes #104